### PR TITLE
Add alt text to all docs images

### DIFF
--- a/account-management/account-settings.md
+++ b/account-management/account-settings.md
@@ -7,7 +7,7 @@ description: View and manage the settings for your personal GitBook account.
 
 You can manage your login details, third-party login options, GitBook subdomain, interface theme, notification, integrations and API access tokens.
 
-<figure><img src="../.gitbook/assets/10_01_25_account_settings.svg" alt=""><figcaption><p>Your personal settings page.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_account_settings.svg" alt="A GitBook screenshot showing the personal settings page" ><figcaption><p>Your personal settings page.</p></figcaption></figure>
 
 ### How to access your personal account settings
 

--- a/account-management/billing-faq/cancelling-a-plan.md
+++ b/account-management/billing-faq/cancelling-a-plan.md
@@ -9,7 +9,7 @@ Only administrators can access an organization’s billing settings to cancel a 
 
 If your mind is made up, here’s how to cancel your plan:
 
-1. Go to the organization’s settings page. You can click on the settings <img src="../../.gitbook/assets/settings.png" alt="" data-size="line"> icon at the bottom of the sidebar and then click on **\[organization name] settings** to get there.
+1. Go to the organization’s settings page. You can click on the settings <img src="../../.gitbook/assets/settings.png" alt="An icon showing a settings gear" data-size="line"> icon at the bottom of the sidebar and then click on **\[organization name] settings** to get there.
 2. Click on the **billing** tab. This will take you to a billing page hosted on Stripe, our payment processor.
 
    <div data-full-width="true">

--- a/account-management/billing-faq/cancelling-a-plan.md
+++ b/account-management/billing-faq/cancelling-a-plan.md
@@ -9,7 +9,7 @@ Only administrators can access an organization’s billing settings to cancel a 
 
 If your mind is made up, here’s how to cancel your plan:
 
-1. Go to the organization’s settings page. You can click on the settings <img src="../../.gitbook/assets/settings.png" alt="An icon showing a settings gear" data-size="line"> icon at the bottom of the sidebar and then click on **\[organization name] settings** to get there.
+1. Go to the organization’s settings page. You can click on the settings <img src="../../.gitbook/assets/settings.png" alt="The settings icon in GitBook" data-size="line"> icon at the bottom of the sidebar and then click on **\[organization name] settings** to get there.
 2. Click on the **billing** tab. This will take you to a billing page hosted on Stripe, our payment processor.
 
    <div data-full-width="true">

--- a/account-management/cancelling-a-plan.md
+++ b/account-management/cancelling-a-plan.md
@@ -11,7 +11,7 @@ Here’s how to cancel your plan:
 
 1.  Go to the organization’s settings page. You can click on the settings&#x20;
 
-    <picture><source srcset="../.gitbook/assets/settings_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/settings_icon_light.svg" alt=""></picture>
+    <picture><source srcset="../.gitbook/assets/settings_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/settings_icon_light.svg" alt="The Settings icon in GitBook"></picture>
 
     &#x20;icon at the bottom of the sidebar and then click on **\[organization name] settings** to get there.
 2. Click on the **billing** tab. This will take you to a billing page hosted on Stripe, our payment processor.

--- a/account-management/organization-settings.md
+++ b/account-management/organization-settings.md
@@ -6,7 +6,7 @@ icon: sitemap
 
 View and manage the settings for your GitBook organization. These include member management, sign-in methods, integrations, billing and plans.
 
-<figure><img src="../.gitbook/assets/10_01_25_organization_settings.svg" alt=""><figcaption><p>Your organization settings page.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_organization_settings.svg" alt="A GitBook screenshot showing the organization settings page" ><figcaption><p>Your organization settings page.</p></figcaption></figure>
 
 ### How to access the settings for an organization
 

--- a/account-management/plans/community/sponsored-site-plan.md
+++ b/account-management/plans/community/sponsored-site-plan.md
@@ -10,7 +10,7 @@ description: >-
 This site plan is only available to users on our [community plan](./).
 {% endhint %}
 
-<figure><img src="../../../.gitbook/assets/10_01_25_sponsored_site_plan_hero.svg" alt=""><figcaption><p>Learn more about the sponsored site plan in GitBook.</p></figcaption></figure>
+<figure><img src="../../../.gitbook/assets/10_01_25_sponsored_site_plan_hero.svg" alt="A GitBook screenshot showing the sponsored site plan hero section" ><figcaption><p>Learn more about the sponsored site plan in GitBook.</p></figcaption></figure>
 
 The sponsored site plan lets you access all of GitBook’s best docs site features at no cost while displaying a small, relevant ad in the corner of your documentation site. Each view generates revenue for you, turning your documentation into a source of income.
 

--- a/account-management/sso-and-saml/README.md
+++ b/account-management/sso-and-saml/README.md
@@ -13,7 +13,7 @@ When you create or manage your organisation, you can add a list of email domains
 
 You can enable email domain SSO in the ’SSO’ section of your organization settings; enter a comma-separated list of email domains you’d like to allow SSO access for and you’re good to go.
 
-<figure><img src="../../.gitbook/assets/10_01_25_sso.svg" alt=""><figcaption><p>Set up SSO for your organization.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_sso.svg" alt="A GitBook screenshot showing how to configure SSO" ><figcaption><p>Set up SSO for your organization.</p></figcaption></figure>
 
 {% hint style="info" %}
 Anyone who joins via an SSO email domain will default to guest access, you can change their role at any time in the members section of your organization settings.

--- a/api-references/openapi/add-an-openapi-specification.md
+++ b/api-references/openapi/add-an-openapi-specification.md
@@ -8,7 +8,7 @@ description: >-
 
 If you have an OpenAPI spec, you can add it to your organization by uploading the file directly, linking to a hosted URL, or using the [GitBook CLI](broken-reference).
 
-<figure><img src="../../.gitbook/assets/02_04_25_add_api_spec.svg" alt="A GitBook screenshot showing where to add an OpenAPI specification" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/02_04_25_add_api_spec.svg" alt="A GitBook screenshot showing the modal for generating API docs automatically" ><figcaption></figcaption></figure>
 
 ### How to add a specification
 

--- a/api-references/openapi/add-an-openapi-specification.md
+++ b/api-references/openapi/add-an-openapi-specification.md
@@ -8,7 +8,7 @@ description: >-
 
 If you have an OpenAPI spec, you can add it to your organization by uploading the file directly, linking to a hosted URL, or using the [GitBook CLI](broken-reference).
 
-<figure><img src="../../.gitbook/assets/02_04_25_add_api_spec.svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/02_04_25_add_api_spec.svg" alt="A GitBook screenshot showing where to add an OpenAPI specification" ><figcaption></figcaption></figure>
 
 ### How to add a specification
 
@@ -20,7 +20,7 @@ If you have an OpenAPI spec, you can add it to your organization by uploading th
    * Enter a URL to a hosted spec
    * Use the CLI to publish the spec
 
-<figure><img src="../../.gitbook/assets/03_04_25_api_spec_modal (1).svg" alt=""><figcaption><p>Add an OpenAPI specification modal.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/03_04_25_api_spec_modal (1).svg" alt="A GitBook screenshot showing the Add an OpenAPI specification modal"><figcaption><p>Add an OpenAPI specification modal.</p></figcaption></figure>
 
 ### Update your specification
 

--- a/api-references/openapi/insert-api-reference-in-your-docs.md
+++ b/api-references/openapi/insert-api-reference-in-your-docs.md
@@ -16,7 +16,7 @@ Endpoints added from your spec will continue to be updated anytime your spec is 
 
 After you’ve [added your OpenAPI spec](add-an-openapi-specification.md), you can generate endpoint pages by inserting an **OpenAPI Reference** in the table of contents of a Space.
 
-<figure><img src="../../.gitbook/assets/03_04_25_create_api_pages.svg" alt="A GitBook screenshot showing how to insert API references into the table of contents" ><figcaption><p>Insert API References in the table of contents of a Space.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/03_04_25_create_api_pages.svg" alt="A GitBook screenshot showing how to insert API references into the table of contents of a space" ><figcaption><p>Insert API References in the table of contents of a Space.</p></figcaption></figure>
 
 {% stepper %}
 {% step %}

--- a/api-references/openapi/insert-api-reference-in-your-docs.md
+++ b/api-references/openapi/insert-api-reference-in-your-docs.md
@@ -16,7 +16,7 @@ Endpoints added from your spec will continue to be updated anytime your spec is 
 
 After you’ve [added your OpenAPI spec](add-an-openapi-specification.md), you can generate endpoint pages by inserting an **OpenAPI Reference** in the table of contents of a Space.
 
-<figure><img src="../../.gitbook/assets/03_04_25_create_api_pages.svg" alt=""><figcaption><p>Insert API References in the table of contents of a Space.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/03_04_25_create_api_pages.svg" alt="A GitBook screenshot showing how to insert API references into the table of contents" ><figcaption><p>Insert API References in the table of contents of a Space.</p></figcaption></figure>
 
 {% stepper %}
 {% step %}

--- a/collaboration/change-requests.md
+++ b/collaboration/change-requests.md
@@ -9,7 +9,7 @@ A change request is a copy of your main content. It comes from the simple concep
 
 In a change request, you can edit, update and delete elements of your content, request reviews on your changes, then merge them back into your main version to apply all the changes you made.
 
-<figure><img src="../.gitbook/assets/10_01_25_change_requests.svg" alt=""><figcaption><p>Edit your content through change requests.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_change_requests.svg" alt="A GitBook screenshot showing the change requests panel" ><figcaption><p>Edit your content through change requests.</p></figcaption></figure>
 
 ### Creating a change request
 
@@ -120,4 +120,4 @@ If you don’t want to choose between versions, you can resolve a merge conflict
 
 If you decide not to merge a change request and want to remove it from the queue, you can archive it.
 
-To archive a change request, first open it up. Then click the **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt=""></picture> next to the change request’s title and choose **Archive**. You can find and reopen archived change requests later by opening the **Change Requests** menu and selecting the **Archived** tab.
+To archive a change request, first open it up. Then click the **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt="The Actions menu icon in GitBook"></picture> next to the change request’s title and choose **Archive**. You can find and reopen archived change requests later by opening the **Change Requests** menu and selecting the **Archived** tab.

--- a/collaboration/collaboration/change-requests.md
+++ b/collaboration/collaboration/change-requests.md
@@ -6,7 +6,7 @@ description: Learn about editing with change requests
 
 <div data-full-width="true">
 
-<figure><img src="../../.gitbook/assets/Change requests collab.png" alt=""><figcaption><p>The change requests panel</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Change requests collab.png" alt="A GitBook screenshot showing the change requests panel" ><figcaption><p>The change requests panel</p></figcaption></figure>
 
 </div>
 
@@ -26,7 +26,7 @@ In a space that is **locked** for live edits, hit the ’Edit’ button in the s
 
 <div data-full-width="true">
 
-<figure><img src="../../.gitbook/assets/start a change request.png" alt=""><figcaption><p>Click the "Edit" button in the top right corner to start a change request</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/start a change request.png" alt="A GitBook screenshot showing how to start a change request" ><figcaption><p>Click the "Edit" button in the top right corner to start a change request</p></figcaption></figure>
 
 </div>
 
@@ -42,7 +42,7 @@ Once you’re happy with your changes, you can **submit** the change request.
 
 <div data-full-width="true">
 
-<figure><img src="../../.gitbook/assets/submit for review.png" alt=""><figcaption><p>Submit your change request for review in the bottom right corner of the editor</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/submit for review.png" alt="A GitBook screenshot showing the submit for review button" ><figcaption><p>Submit your change request for review in the bottom right corner of the editor</p></figcaption></figure>
 
 </div>
 

--- a/collaboration/collaboration/live-edits.md
+++ b/collaboration/collaboration/live-edits.md
@@ -26,7 +26,7 @@ You can lock or unlock space for live edits by selecting ’Unlock live edits’
 
 <div data-full-width="true">
 
-<figure><img src="../../.gitbook/assets/Unlock live edits.png" alt=""><figcaption><p>Unlock live edits from the space actions menu</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Unlock live edits.png" alt="A GitBook screenshot showing the Unlock live edits option" ><figcaption><p>Unlock live edits from the space actions menu</p></figcaption></figure>
 
 </div>
 

--- a/collaboration/comments.md
+++ b/collaboration/comments.md
@@ -9,7 +9,7 @@ Comments allow you to provide feedback around specific pieces of content — wit
 
 ### Add a comment <a href="#comment-within-your-content" id="comment-within-your-content"></a>
 
-You can open the comments panel by clicking on the **Comments** button <picture><source srcset="../.gitbook/assets/comment_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/comment_icon_light.svg" alt=""></picture> in the [space header](../resources/gitbook-ui.md#space-header).
+You can open the comments panel by clicking on the **Comments** button <picture><source srcset="../.gitbook/assets/comment_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/comment_icon_light.svg" alt="The Comments button icon in GitBook"></picture> in the [space header](../resources/gitbook-ui.md#space-header).
 
 Adding a comment here will attach a comment to the entire page. You can also comment on a specific block by hovering over a block and clicking the content icon that appears on the right.
 

--- a/collaboration/live-edits.md
+++ b/collaboration/live-edits.md
@@ -13,7 +13,7 @@ GitBook supports live collaboration, meaning you’ll be able to work on the sam
 
 ### Toggling live edit mode
 
-You can toggle live edit mode in a space by selecting **Lock live edits** or **Unlock live edits** from the [space header’s](../resources/gitbook-ui.md#space-header) **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt=""></picture>.&#x20;
+You can toggle live edit mode in a space by selecting **Lock live edits** or **Unlock live edits** from the [space header’s](../resources/gitbook-ui.md#space-header) **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt="The Actions menu icon in GitBook"></picture>.&#x20;
 
 When a space is in **Live edits** mode, the space header will show the **Editor** tab. When it is in **Locked live edits** mode, the space header will show a **Read-only** tab. When the Read-only tab appears in the space header, you will need to open a change request to edit the content of the page.
 

--- a/collaboration/pdf-export.md
+++ b/collaboration/pdf-export.md
@@ -23,14 +23,14 @@ Note that links across spaces are not currently supported when exporting interna
 
 #### Export an individual page
 
-1. Open the page you want to export, then open the page’s [Actions menu](../resources/gitbook-ui.md#the-actions-menu) <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> next to the page title.
+1. Open the page you want to export, then open the page’s [Actions menu](../resources/gitbook-ui.md#the-actions-menu) <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> next to the page title.
 2. Select **Export to PDF > Current page**.
 3. Wait for the page to load, then click the **Print or save as PDF** button in the upper right to open your browsers Print menu.
 4. From here, you can save the page as a PDF or open it in your PDF viewer using the typical process for your browser.
 
 #### Export an entire space
 
-1. Open the[ Actions menu](../creating-content/content-structure/) <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> next to the page title and choose **Export as PDF > All pages**. Alternatively, open the space’s **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt=""></picture> in the [space header](../resources/gitbook-ui.md#space-header) and choose **Export as PDF** in the drop-down menu.\
+1. Open the[ Actions menu](../creating-content/content-structure/) <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> next to the page title and choose **Export as PDF > All pages**. Alternatively, open the space’s **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt="The Actions menu icon in GitBook"></picture> in the [space header](../resources/gitbook-ui.md#space-header) and choose **Export as PDF** in the drop-down menu.\
    \
    &#xNAN;_&#x4E;ote: This action is not available within a change request._
 2. Wait for the page to load, then click the **Print or save as PDF** button in the upper right to open your browsers Print menu.

--- a/collaboration/share.md
+++ b/collaboration/share.md
@@ -5,7 +5,7 @@ description: Collaborate with your teammates on spaces, collections and more
 
 # Inviting your team
 
-<figure><img src="../.gitbook/assets/10_01_25_invite_team.svg" alt=""><figcaption><p>Invite your team to GitBook to collaborate on pages, spaces, and published sites.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_invite_team.svg" alt="A GitBook screenshot showing the invite team dialog" ><figcaption><p>Invite your team to GitBook to collaborate on pages, spaces, and published sites.</p></figcaption></figure>
 
 ### Sharing a space or collection
 
@@ -45,4 +45,4 @@ If you don’t want to use email to invite someone to your content, or want to i
 
 When you share this link, anyone who clicks on it will be able to sign up, join your organization as a [guest](../account-management/member-management/roles.md#guest-role), and get access to just this single space and its content.&#x20;
 
-You can revoke the link at any time by opening the **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> next to the link and choosing **Revoke**.
+You can revoke the link at any time by opening the **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> next to the link and choosing **Revoke**.

--- a/creating-content/blocks/README.md
+++ b/creating-content/blocks/README.md
@@ -7,7 +7,7 @@ icon: square-dashed-circle-plus
 
 GitBook is a block-based editor, meaning you can add different kinds of blocks to your content — from standard text and images to interactive blocks. Your pages can include any combination of blocks you want, and there’s no limit to the number of blocks you can have on a page.
 
-<figure><img src="../../.gitbook/assets/10_01_25_content_blocks.svg" alt=""><figcaption><p>GitBook's built in content blocks.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_content_blocks.svg" alt="A GitBook screenshot showing the available content blocks" ><figcaption><p>GitBook's built in content blocks.</p></figcaption></figure>
 
 ### Inserting a new content block
 
@@ -41,7 +41,7 @@ Once selected, you can:
 
 By making your blocks full width, you can create a clear visual hierarchy in your content, or simply give more space to content that needs it.
 
-To make a block full width, click on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> next to your block and select **Full width**. This feature is available for the following block types:
+To make a block full width, click on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> next to your block and select **Full width**. This feature is available for the following block types:
 
 * Code Blocks
 * Image blocks

--- a/creating-content/blocks/cards.md
+++ b/creating-content/blocks/cards.md
@@ -14,7 +14,7 @@ You can adjust [switch between medium or large cards](cards.md#card-size) and li
 
 ### Adding links <a href="#adding-links-and-images-to-your-cards" id="adding-links-and-images-to-your-cards"></a>
 
-Hover over a card and open its **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture>. Here you can add a target link, so users can jump directly to a location when they click the card.
+Hover over a card and open its **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture>. Here you can add a target link, so users can jump directly to a location when they click the card.
 
 {% hint style="success" %}
 When creating cards, we recommend you use **target links instead of hyperlinks**. With a target link, your readers can click anywhere on the card to access the linked URL.
@@ -22,7 +22,7 @@ When creating cards, we recommend you use **target links instead of hyperlinks**
 
 ### Adding images
 
-Hover over a card and open its **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture>. Here you can add a cover image to your card. Alternatively, just click the **Add cover image** option on the card itself.
+Hover over a card and open its **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture>. Here you can add a cover image to your card. Alternatively, just click the **Add cover image** option on the card itself.
 
 This will open the **Select file** modal. Here you can drag and drop a new image into this, or use an image file you’ve previously uploaded to your space.
 
@@ -30,9 +30,9 @@ This will open the **Select file** modal. Here you can drag and drop a new imag
 
 GitBook will automatically crop landscape images to a 16:9 ratio on desktop and mobile. If the images you upload are portrait or have a 1:1 ratio, they will be cropped to 16:9 on desktop and display as square or portrait on mobile.
 
-<figure><img src="../../.gitbook/assets/13_02_25_cards_desktop.svg" alt=""><figcaption><p>On desktop, all card images will display in a landscape 16:9 ratio, regardless of their dimensions. We recommend using the same dimensions for consistency.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/13_02_25_cards_desktop.svg" alt="A GitBook screenshot showing card images on desktop" ><figcaption><p>On desktop, all card images will display in a landscape 16:9 ratio, regardless of their dimensions. We recommend using the same dimensions for consistency.</p></figcaption></figure>
 
-<figure><img src="../../.gitbook/assets/13_02_25_cards_mobile.svg" alt=""><figcaption><p>On mobile, square or portrait images will displayed as shown on the left. Landscape images will be displayed as shown on the right.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/13_02_25_cards_mobile.svg" alt="A GitBook screenshot showing card images on mobile" ><figcaption><p>On mobile, square or portrait images will displayed as shown on the left. Landscape images will be displayed as shown on the right.</p></figcaption></figure>
 
 To keep things consistent across desktop and mobile, we recommend uploading all the images for your cards in a 16:9 format (e.g. 1920px x 1080px).
 
@@ -40,8 +40,8 @@ If you want your cards to adapt their layout depending on the screen size, we’
 
 ### Changing the size of cards
 
-You can select the card size by opening the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> to the left of your card block. The **Medium** option creates three cards in one horizontal line, while the **Large** option shows two larger cards on each line.
+You can select the card size by opening the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> to the left of your card block. The **Medium** option creates three cards in one horizontal line, while the **Large** option shows two larger cards on each line.
 
 {% hint style="info" %}
-You can make card blocks [span the full width of your window](./#full-width-blocks) by clicking on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="" data-size="line"></picture> next to the block and choosing **Full width**.
+You can make card blocks [span the full width of your window](./#full-width-blocks) by clicking on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook" data-size="line"></picture> next to the block and choosing **Full width**.
 {% endhint %}

--- a/creating-content/blocks/code-block.md
+++ b/creating-content/blocks/code-block.md
@@ -59,12 +59,12 @@ greeting.("Anna")
 {% endtabs %}
 
 {% hint style="info" %}
-You can make code blocks [span the full width of your window](./#full-width-blocks) by clicking on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> next to the block and choosing **Full width**.
+You can make code blocks [span the full width of your window](./#full-width-blocks) by clicking on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> next to the block and choosing **Full width**.
 {% endhint %}
 
 ### Code block options <a href="#options" id="options"></a>
 
-When you click on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> next to the code block, or the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> in the block itself, you’ll see a number of options you can set.
+When you click on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> next to the code block, or the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> in the block itself, you’ll see a number of options you can set.
 
 #### Set syntax… <a href="#set-syntax" id="set-syntax"></a>
 

--- a/creating-content/blocks/columns.md
+++ b/creating-content/blocks/columns.md
@@ -16,6 +16,6 @@ Integrate your documentation right into your product experience, or give users a
 {% endcolumn %}
 
 {% column %}
-<figure><img src="../../.gitbook/assets/GitBook vision post.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/GitBook vision post.png" alt="A screenshot of the GitBook vision post"><figcaption></figcaption></figure>
 {% endcolumn %}
 {% endcolumns %}

--- a/creating-content/blocks/columns.md
+++ b/creating-content/blocks/columns.md
@@ -16,6 +16,6 @@ Integrate your documentation right into your product experience, or give users a
 {% endcolumn %}
 
 {% column %}
-<figure><img src="../../.gitbook/assets/GitBook vision post.png" alt="A screenshot of the GitBook vision post"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/GitBook vision post.png" alt="An image of GitBook icons demonstrating side by side column functionality"><figcaption></figcaption></figure>
 {% endcolumn %}
 {% endcolumns %}

--- a/creating-content/blocks/drawing.md
+++ b/creating-content/blocks/drawing.md
@@ -12,7 +12,7 @@ GitBook stores drawings as special SVG files in the space. Those files have an e
 
 ### Example of a drawing block
 
-<img src="../../.gitbook/assets/diagram.excalidraw.svg" alt="" class="gitbook-drawing">
+<img src="../../.gitbook/assets/diagram.excalidraw.svg" alt="A diagram drawn in GitBook" class="gitbook-drawing">
 
 ### Draw with GitBook AI
 

--- a/creating-content/blocks/heading.md
+++ b/creating-content/blocks/heading.md
@@ -22,7 +22,7 @@ If you want to link to a particular anchor from a page within your GitBook space
 
 By default, the anchor link will be identical to the text in your header. If you plan to link to that URL outside of GitBook, changing the header in future will break the anchor link. The link will then take visitors to the top of the page, rather than the anchor location.
 
-To avoid this, you can manually set the anchor link by opening the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> for the header, then choosing **Edit anchor**. You can then enter the anchor link you wish to use — this will remain the anchor even if you change the header itself.
+To avoid this, you can manually set the anchor link by opening the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> for the header, then choosing **Edit anchor**. You can then enter the anchor link you wish to use — this will remain the anchor even if you change the header itself.
 
 ### Heading examples <a href="#example-of-a-heading" id="example-of-a-heading"></a>
 

--- a/creating-content/blocks/hint.md
+++ b/creating-content/blocks/hint.md
@@ -8,7 +8,7 @@ description: >-
 
 Hints are a great way to bring the reader’s attention to specific elements in your documentation, such as tips, warnings, and other important information.
 
-There are four different hint styles — you can change the style by clicking the colored icon, or by opening the block’s **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> and selecting the style you want.
+There are four different hint styles — you can change the style by clicking the colored icon, or by opening the block’s **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> and selecting the style you want.
 
 Hint blocks support [inline content](../formatting/inline.md) and [formatting](../formatting/), as well some specific block types. To see which block types you can use in a hint, hit `/` on an empty line and check the [insert palette](./#inserting-a-new-content-block).
 
@@ -35,7 +35,7 @@ Hint blocks support [inline content](../formatting/inline.md) and [formatting](.
 
 This is a line
 
-This is an inline <img src="../../.gitbook/assets/command_icon_light.svg" alt="" data-size="line"> image
+This is an inline <img src="../../.gitbook/assets/command_icon_light.svg" alt="An icon showing a command" data-size="line"> image
 
 * This is a second <mark style="color:orange;background-color:purple;">line using an unordered list and color</mark>
 {% endhint %}
@@ -68,7 +68,7 @@ To add a heading to your hint, you need to create a heading block as the the fir
 
 This is a line
 
-This is an inline <img src=".gitbook/assets/notification.png" alt="" data-size="line"> image
+This is an inline <img src=".gitbook/assets/notification.png" alt="An icon showing a notification" data-size="line"> image
 
 - This is a second <mark style="color:orange;background-color:purple;">line using an unordered list and color</mark>
 {% endhint %}

--- a/creating-content/blocks/hint.md
+++ b/creating-content/blocks/hint.md
@@ -35,7 +35,7 @@ Hint blocks support [inline content](../formatting/inline.md) and [formatting](.
 
 This is a line
 
-This is an inline <img src="../../.gitbook/assets/command_icon_light.svg" alt="An icon showing a command" data-size="line"> image
+This is an inline <img src="../../.gitbook/assets/command_icon_light.svg" alt="The Apple computer command icon" data-size="line"> image
 
 * This is a second <mark style="color:orange;background-color:purple;">line using an unordered list and color</mark>
 {% endhint %}
@@ -68,7 +68,7 @@ To add a heading to your hint, you need to create a heading block as the the fir
 
 This is a line
 
-This is an inline <img src=".gitbook/assets/notification.png" alt="An icon showing a notification" data-size="line"> image
+This is an inline <img src="../../.gitbook/assets/command_icon_light.svg" alt="The Apple computer command icon" data-size="line"> image
 
 - This is a second <mark style="color:orange;background-color:purple;">line using an unordered list and color</mark>
 {% endhint %}

--- a/creating-content/blocks/insert-files.md
+++ b/creating-content/blocks/insert-files.md
@@ -34,11 +34,11 @@ You can also add files to your space when you add an [image block](insert-images
 
 ### Renaming a file
 
-To rename a file, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> for the file, and click **Edit**. In the dialog prompt, enter the new name of your file.
+To rename a file, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> for the file, and click **Edit**. In the dialog prompt, enter the new name of your file.
 
 ### Deleting a file
 
-To delete a file, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> for the file and click **Delete**. After confirming in the dialog that you’re sure you want to delete the file, your file will be deleted.
+To delete a file, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> for the file and click **Delete**. After confirming in the dialog that you’re sure you want to delete the file, your file will be deleted.
 
 {% hint style="warning" %}
 **Note:** Make sure you update any pages that included your deleted file! File blocks that reference a deleted file will show an empty block, or _Could not load image_ error.
@@ -48,7 +48,7 @@ To delete a file, open the **Actions menu** <picture><source srcset="../../.gitb
 
 If you have a file that simply needs updating to a new version, you can replace it. This will swap out the old file and put the new file in its place. Any blocks that previously referred to the old file will then refer to the new file.
 
-To replace a file, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> for the file and click **Replace**. In the file replacement dialog that appears, select the new file and wait for the upload indicator to complete. Your file will automatically update everywhere it appeared in your space.
+To replace a file, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> for the file and click **Replace**. In the file replacement dialog that appears, select the new file and wait for the upload indicator to complete. Your file will automatically update everywhere it appeared in your space.
 
 This can be helpful if, for example, you’ve had a major product redesign and need to update outdated UI screenshots that appear on multiple pages. Replacing the original file would update the screenshot everywhere in your space, saving you time and effort.
 

--- a/creating-content/blocks/insert-images.md
+++ b/creating-content/blocks/insert-images.md
@@ -14,7 +14,7 @@ You can insert images into your page, then choose their size and whether to alig
 
 ### Example of an image block <a href="#example-of-an-image-block" id="example-of-an-image-block"></a>
 
-<div align="center"><img src="https://images.unsplash.com/photo-1446776709462-d6b525c57bd3?crop=entropy&#x26;cs=srgb&#x26;fm=jpg&#x26;ixid=M3wxOTcwMjR8MHwxfHNlYXJjaHwyfHxzcGFjZXxlbnwwfHx8fDE3MzMxOTY5NTR8MA&#x26;ixlib=rb-4.0.3&#x26;q=85" alt="By default, an image block will appear at full-width."></div>
+<div align="center"><img src="https://images.unsplash.com/photo-1446776709462-d6b525c57bd3?crop=entropy&#x26;cs=srgb&#x26;fm=jpg&#x26;ixid=M3wxOTcwMjR8MHwxfHNlYXJjaHwyfHxzcGFjZXxlbnwwfHx8fDE3MzMxOTY5NTR8MA&#x26;ixlib=rb-4.0.3&#x26;q=85" alt="A photograph taken from space looking back towards Earth. A satellite is in the foreground, and in the background is an ocean-covered part of our planet with patchy clouds."></div>
 
 ### Uploading an image
 

--- a/creating-content/blocks/insert-images.md
+++ b/creating-content/blocks/insert-images.md
@@ -31,15 +31,15 @@ GitBook allows you to upload images up to 100MB per file.
 
 #### Create an image gallery
 
-Adding more than one image to an image block will create a gallery. To do this, open the block’s **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> and choose **Add images…** to open the **Select images** side panel again.
+Adding more than one image to an image block will create a gallery. To do this, open the block’s **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> and choose **Add images…** to open the **Select images** side panel again.
 
-To delete an image from a gallery, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> on the image you want to delete and press the **Delete ⌫** key.
+To delete an image from a gallery, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> on the image you want to delete and press the **Delete ⌫** key.
 
 ### Adding images for light & dark mode <a href="#light-and-dark-mode" id="light-and-dark-mode"></a>
 
 You can set different images for the light and dark mode versions of your published site. GitBook will automatically display the correct image depending on the mode your visitor is in.
 
-To add an image for dark mode, hover over your image, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> and click **Replace image** <picture><source srcset="../../.gitbook/assets/replace_image_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/replace_image_icon_light.svg" alt=""></picture>.&#x20;
+To add an image for dark mode, hover over your image, open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> and click **Replace image** <picture><source srcset="../../.gitbook/assets/replace_image_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/replace_image_icon_light.svg" alt="The Replace image icon in GitBook"></picture>.&#x20;
 
 In the drop-down menu, choose **Add image for Dark mode**. Once you’ve set this, you can replace either image from this same menu.
 
@@ -98,9 +98,9 @@ and text after the image
 
 ### Resizing
 
-To resize your image, hover over it and open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture>. Click the **Size** button to change the size of your image from the available options.
+To resize your image, hover over it and open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture>. Click the **Size** button to change the size of your image from the available options.
 
-<figure><img src="../../.gitbook/assets/10_01_25_image_resizing.svg" alt=""><figcaption><p>Resize an image</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_image_resizing.svg" alt="A GitBook screenshot showing how to resize an image" ><figcaption><p>Resize an image</p></figcaption></figure>
 
 - **Small** – 25% of the image size
 - **Medium** – 50% of the image size
@@ -114,7 +114,7 @@ If your image is wider than the editor, GitBook will limit the image’s width t
 {% endhint %}
 
 {% hint style="info" %}
-You can make image blocks [span the full width of your window](./#full-width-blocks) by clicking on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> next to the block and choosing **Full width**.
+You can make image blocks [span the full width of your window](./#full-width-blocks) by clicking on the **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> next to the block and choosing **Full width**.
 {% endhint %}
 
 ### Resizing images through Git Sync
@@ -132,7 +132,7 @@ Valid variants for specifying the image dimensions are:\
 
 By default, image blocks will show your image at its full size, aligned centrally.
 
-To change the alignment of an image, open the block’s **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> and choose the alignment you want. This will only affect images that are narrower than the editor, or images you’ve [resized](insert-images.md#resizing).
+To change the alignment of an image, open the block’s **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> and choose the alignment you want. This will only affect images that are narrower than the editor, or images you’ve [resized](insert-images.md#resizing).
 
 ### Representation in Markdown
 

--- a/creating-content/blocks/table.md
+++ b/creating-content/blocks/table.md
@@ -47,7 +47,7 @@ Tables that are wider than the editor container will be horizontally scrollable.
 
 ### Column options
 
-To reorder columns, click and drag on the drag handle <picture><source srcset="../../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions-horizontal.svg" alt="The Actions menu icon in GitBook"></picture> at the top of the column you want to move.
+To reorder columns, click and drag on the drag handle <picture><source srcset="../../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions-horizontal.svg" alt="The table drag handle icon in GitBook"></picture> at the top of the column you want to move.
 
 You can add new columns by clicking the **Add column** button that appears when you hover over the right edge of the table.
 

--- a/creating-content/blocks/table.md
+++ b/creating-content/blocks/table.md
@@ -55,7 +55,7 @@ Inside the **Column options** menu you can also switch automatic sizing on and o
 
 ### Row options
 
-Hover over the row and click the **Row options** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> button that appears on the left of it to open the **Row options** menu. You’ll see a number of options:
+Hover over the row and click the **Row options** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Row options menu icon in GitBook"></picture> button that appears on the left of it to open the **Row options** menu. You’ll see a number of options:
 
 * **Open row:** Open the row in a modal that shows all of its data. Here you can quickly change row types, edit data, and see data in hidden columns.
 * **Insert above/below:** Add a new row above or below the currently-selected row.

--- a/creating-content/blocks/table.md
+++ b/creating-content/blocks/table.md
@@ -47,7 +47,7 @@ Tables that are wider than the editor container will be horizontally scrollable.
 
 ### Column options
 
-To reorder columns, click and drag on the drag handle <picture><source srcset="../../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions-horizontal.svg" alt=""></picture> at the top of the column you want to move.
+To reorder columns, click and drag on the drag handle <picture><source srcset="../../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions-horizontal.svg" alt="The Actions menu icon in GitBook"></picture> at the top of the column you want to move.
 
 You can add new columns by clicking the **Add column** button that appears when you hover over the right edge of the table.
 
@@ -55,7 +55,7 @@ Inside the **Column options** menu you can also switch automatic sizing on and o
 
 ### Row options
 
-Hover over the row and click the **Row options** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> button that appears on the left of it to open the **Row options** menu. You’ll see a number of options:
+Hover over the row and click the **Row options** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> button that appears on the left of it to open the **Row options** menu. You’ll see a number of options:
 
 * **Open row:** Open the row in a modal that shows all of its data. Here you can quickly change row types, edit data, and see data in hidden columns.
 * **Insert above/below:** Add a new row above or below the currently-selected row.

--- a/creating-content/blocks/tabs.md
+++ b/creating-content/blocks/tabs.md
@@ -12,7 +12,7 @@ Each tab can contain multiple other blocks, of any type. So you can add code blo
 
 ### Add or delete tabs
 
-To add a new tab to a tab block, hover over the edge of a tab and click the `+` button that appears. To delete a tab, open the tab’s **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> then select **Delete**.
+To add a new tab to a tab block, hover over the edge of a tab and click the `+` button that appears. To delete a tab, open the tab’s **Options menu** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> then select **Delete**.
 
 ### Example
 

--- a/creating-content/broken-links.md
+++ b/creating-content/broken-links.md
@@ -7,7 +7,7 @@ description: Find and replace broken relative links across your spaces
 
 {% include "../.gitbook/includes/pro-and-enterprise-hint.md" %}
 
-<div data-full-width="false"><figure><img src="../.gitbook/assets/10_01_25_broken_links_sidebar.svg" alt=""><figcaption><p>The <strong>Broken links</strong> panel that you can open on the right of a space to check for broken internal links.</p></figcaption></figure></div>
+<div data-full-width="false"><figure><img src="../.gitbook/assets/10_01_25_broken_links_sidebar.svg" alt="A GitBook screenshot showing the Broken links panel" ><figcaption><p>The <strong>Broken links</strong> panel that you can open on the right of a space to check for broken internal links.</p></figcaption></figure></div>
 
 You can add different [types of links](formatting/inline.md#links) to your pages in GitBook. If someone has broken a [relative link](formatting/inline.md#relative-links) while making a change request by updating it or changing its location, you’ll see a notification letting you know there’s something to fix.
 

--- a/creating-content/content-structure/collection.md
+++ b/creating-content/content-structure/collection.md
@@ -15,7 +15,7 @@ Click the **+** button next to the **Spaces** header in the sidebar to create a 
 
 ### Move a collection
 
-You can move a collection by opening the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture>, selecting **Move collection to…** and choosing a destination. Alternatively, you can drag and drop collections in the sidebar to move or reorder them.\
+You can move a collection by opening the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture>, selecting **Move collection to…** and choosing a destination. Alternatively, you can drag and drop collections in the sidebar to move or reorder them.\
 \
 You can move collections into other collections — or even to other organizations, if you have an [admin role](../../account-management/member-management/roles.md) in both.
 
@@ -25,11 +25,11 @@ You can nest collections inside each other, creating a collection -> sub-collect
 
 Open a collection and you can click **New collection** from the collection’s main page to create a sub-collection.
 
-To move one collection into another, click **Move collection to…** from the collection’s **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> and then choose its new location. Alternatively, you can drag and drop the collection to its new location.
+To move one collection into another, click **Move collection to…** from the collection’s **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> and then choose its new location. Alternatively, you can drag and drop the collection to its new location.
 
 ### How to delete a collection
 
-You can delete a collection by opening its **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> and selecting **Delete**.
+You can delete a collection by opening its **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> and selecting **Delete**.
 
 {% hint style="danger" %}
 **Deleting a collection is final**, but spaces inside a deleted collection will move to the **Trash** and can be restored up to seven days after deletion. You can access the Trash from the bottom of the sidebar.

--- a/creating-content/content-structure/page.md
+++ b/creating-content/content-structure/page.md
@@ -16,7 +16,7 @@ You can create as many pages as you need in a space. They’re all visible on th
 
 When in [live edit](../../collaboration/live-edits.md) mode or in a [change request](../../collaboration/change-requests.md), you can create a new page by clicking **Add new...** > **Page** at the bottom of your table of contents. Alternatively, you can hover between pages in the table of contents and click the **+** icon that appears.
 
-<figure><img src="../../.gitbook/assets/04_02_25_page.svg" alt=""><figcaption><p>An empty page in GitBook. You can see it listed in the table of contents on the left-hand side.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/04_02_25_page.svg" alt="A GitBook screenshot showing an empty page listed in the table of contents" ><figcaption><p>An empty page in GitBook. You can see it listed in the table of contents on the left-hand side.</p></figcaption></figure>
 
 ### Can’t see the option to create a new page?
 
@@ -42,7 +42,7 @@ You can nest pages by dragging and dropping a page below an other in the table o
 
 When you change the title of a page, the page’s slug (the part at the very end of the URL, e.g. `/hello-world`) will also change — unless you’ve manually set the page’s slug previously.
 
-You can change the title and the slug of a page at any time by clicking opening the page’s **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> and choosing **Rename**.
+You can change the title and the slug of a page at any time by clicking opening the page’s **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> and choosing **Rename**.
 
 #### Page groups
 
@@ -52,7 +52,7 @@ You can create a new page group by clicking **Add new...** > **Group** at the bo
 
 Page groups can only live at the **top level** of the table of contents. You cannot nest page groups inside page groups.
 
-To change the title and slug of a page group, click the **Action menu** icon <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> next to the group title in the table of contents and choose **Rename**.
+To change the title and slug of a page group, click the **Action menu** icon <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> next to the group title in the table of contents and choose **Rename**.
 
 #### External links <a href="#external-links" id="external-links"></a>
 
@@ -72,7 +72,7 @@ In the **Page options** menu you can customize the look and feel of a selected p
 
 **Layout**
 
-You can open the **Page options** <picture><source srcset="../../.gitbook/assets/options_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_icon_light.svg" alt=""></picture> menu or change a page’s cover by hovering over the page title. You’ll see the buttons appear just above the page title.
+You can open the **Page options** <picture><source srcset="../../.gitbook/assets/options_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_icon_light.svg" alt="The Page options menu icon in GitBook"></picture> menu or change a page’s cover by hovering over the page title. You’ll see the buttons appear just above the page title.
 
 In the **Page options** side panel, you can select how each page is displayed to those who visit your **published** content. There are three layout presets to choose from, or you can create a custom layout.
 
@@ -88,7 +88,7 @@ Each layout preset will toggle on or off each of the following parts of the page
 
 You can decide which pages you would like to show/hide in your published documentation, while also deciding if you would like the page to be indexed in your published doc’s search, and/or indexed by search engines.
 
-You can hide a page or group of pages from your site's table of contents by opening the page’s **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> and toggling **Hide page**.
+You can hide a page or group of pages from your site's table of contents by opening the page’s **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> and toggling **Hide page**.
 
 If hidden the following will appear in the front matter of the markdown file when using Git Sync:
 
@@ -99,15 +99,15 @@ hidden: true
 
 ### Page covers
 
-You can also set a page cover for each page of your documentation. When you click the **Page cover** <picture><source srcset="../../.gitbook/assets/image_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/image_icon_light.svg" alt=""></picture> option, a default cover will be added immediately. From here, you can:
+You can also set a page cover for each page of your documentation. When you click the **Page cover** <picture><source srcset="../../.gitbook/assets/image_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/image_icon_light.svg" alt="The Page cover icon in GitBook"></picture> option, a default cover will be added immediately. From here, you can:
 
 *   **Change the cover image**
 
     Hover over the page cover and click **Change cover**, then select or upload an image. Based on how we currently display page covers, 1990x480 pixels is the ideal size.
 *   **Reposition the cover image**
 
-    Hover over the page cover and open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture>. Click **Reposition**, then drag the image as you wish and click **Save**.
+    Hover over the page cover and open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture>. Click **Reposition**, then drag the image as you wish and click **Save**.
 * **Remove the cover image**\
-  Hover over the page cover and open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture>, then click **Remove**.
+  Hover over the page cover and open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture>, then click **Remove**.
 * **Full width and hero width**\
-  You can change the style of your page cover to span the full width of your screen or just the width of your content. Hover over the page cover and open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture>, then choose your preferred option from the menu.
+  You can change the style of your page cover to span the full width of your screen or just the width of your content. Hover over the page cover and open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture>, then choose your preferred option from the menu.

--- a/creating-content/content-structure/space.md
+++ b/creating-content/content-structure/space.md
@@ -6,7 +6,7 @@ description: Organize the content you create and publish into spaces
 
 A space is a project that lets you work on a collection of related pages. They allow you to write content, organize pages, add integrations and more.
 
-<figure><img src="../../.gitbook/assets/10_01_25_space_sidebar.svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_space_sidebar.svg" alt="A GitBook screenshot showing the spaces sidebar"><figcaption></figcaption></figure>
 
 ### Create a space
 
@@ -16,19 +16,19 @@ You can edit a space’s name by hovering over the name in the [space header](..
 
 ### Duplicate a space
 
-To duplicate a space, open that space's **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> in the sidebar and select **Duplicate**.
+To duplicate a space, open that space's **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> in the sidebar and select **Duplicate**.
 
 Duplicating a space will create a copy of the source space, in the same location (organization, collection, sub-collection, etc.).
 
 ### Move a space
 
-You can move a space by opening the space’s **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> in the sidebar, selecting **Move space to…** and choosing a destination. Alternatively, you can drag and drop spaces in the sidebar to move or reorder them.\
+You can move a space by opening the space’s **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> in the sidebar, selecting **Move space to…** and choosing a destination. Alternatively, you can drag and drop spaces in the sidebar to move or reorder them.\
 \
 You can move spaces between collections or even organizations, as long as you have an [admin role](../../account-management/member-management/roles.md) in both.
 
 ### Delete a space
 
-You can delete a space by opening the space’s **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> in the sidebar and selecting **Delete**.
+You can delete a space by opening the space’s **Action menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> in the sidebar and selecting **Delete**.
 
 {% hint style="warning" %}
 **Deleted spaces can be restored from the Trash for up to 7 days**. After this, they will be permanently deleted.

--- a/creating-content/formatting/README.md
+++ b/creating-content/formatting/README.md
@@ -79,7 +79,7 @@ This is [a link that starts an email to a specific address](mailto:support@gitbo
 
 Click the color icon in the context menu, and choose a color for the text or its background.
 
-<figure><img src="../../.gitbook/assets/21_03_25_format-color.svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_03_25_format-color.svg" alt="A GitBook screenshot showing color and background color options"><figcaption></figcaption></figure>
 
 <mark style="color:orange;">This text is orange.</mark>
 

--- a/creating-content/formatting/README.md
+++ b/creating-content/formatting/README.md
@@ -79,7 +79,7 @@ This is [a link that starts an email to a specific address](mailto:support@gitbo
 
 Click the color icon in the context menu, and choose a color for the text or its background.
 
-<figure><img src="../../.gitbook/assets/21_03_25_format-color.svg" alt="A GitBook screenshot showing color and background color options"><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_03_25_format-color.svg" alt="A GitBook screenshot showing the color options button highlighted in the inline palette”><figcaption></figcaption></figure>
 
 <mark style="color:orange;">This text is orange.</mark>
 

--- a/creating-content/formatting/inline.md
+++ b/creating-content/formatting/inline.md
@@ -4,7 +4,7 @@ description: Use the inline palette to add images, links, math & TeX, and more
 
 # Inline content
 
-<figure><img src="../../.gitbook/assets/10_01_25_inline_content.svg" alt=""><figcaption><p>Add inline elements to your content.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_inline_content.svg" alt="A GitBook screenshot showing inline content options" ><figcaption><p>Add inline elements to your content.</p></figcaption></figure>
 
 The inline palette lets you quickly add extra content to your text block without moving your hands away from the keyboard. Simply hit `/` on any text block to open the inline palette. The forward slash will be replaced by the content you choose to insert.
 

--- a/creating-content/formatting/markdown.md
+++ b/creating-content/formatting/markdown.md
@@ -6,7 +6,7 @@ description: >-
 
 # Markdown
 
-<figure><img src="../../.gitbook/assets/10_01_25_markdown.svg" alt=""><figcaption><p>Write Markdown in GitBook.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_markdown.svg" alt="A GitBook screenshot showing Markdown in the editor" ><figcaption><p>Write Markdown in GitBook.</p></figcaption></figure>
 
 GitBook’s editor allows you to create formatted content using Markdown.
 

--- a/creating-content/formatting/markdown.md
+++ b/creating-content/formatting/markdown.md
@@ -6,7 +6,7 @@ description: >-
 
 # Markdown
 
-<figure><img src="../../.gitbook/assets/10_01_25_markdown.svg" alt="A GitBook screenshot showing Markdown in the editor" ><figcaption><p>Write Markdown in GitBook.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_markdown.svg" alt="An image containing the markdown logo" ><figcaption><p>Write Markdown in GitBook.</p></figcaption></figure>
 
 GitBook’s editor allows you to create formatted content using Markdown.
 

--- a/creating-content/reusable-content.md
+++ b/creating-content/reusable-content.md
@@ -11,7 +11,7 @@ icon: repeat
 
 Reusable content lets you sync content across multiple pages and spaces, so you can edit all instances of the block at the same time.
 
-<figure><img src="../.gitbook/assets/04_02_25_reusable_content.svg" alt="A GitBook screenshot showing how to create reusable content" ><figcaption><p>Create reusable content within a space.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/04_02_25_reusable_content.svg" alt="A GitBook screenshot showing reusable content" ><figcaption><p>Create reusable content within a space.</p></figcaption></figure>
 
 ## Fundamentals
 

--- a/creating-content/reusable-content.md
+++ b/creating-content/reusable-content.md
@@ -11,7 +11,7 @@ icon: repeat
 
 Reusable content lets you sync content across multiple pages and spaces, so you can edit all instances of the block at the same time.
 
-<figure><img src="../.gitbook/assets/04_02_25_reusable_content.svg" alt=""><figcaption><p>Create reusable content within a space.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/04_02_25_reusable_content.svg" alt="A GitBook screenshot showing how to create reusable content" ><figcaption><p>Create reusable content within a space.</p></figcaption></figure>
 
 ## Fundamentals
 
@@ -41,7 +41,7 @@ Currently, reusable content only appears in search results within its parent spa
 
 ### **Create reusable content**
 
-To create reusable content, [select one or more blocks](blocks/#selecting-blocks-and-interacting-with-selected-blocks), then open the **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> , select **Turn into**, and choose **Reusable content**. You can also give your block a name to make it easier to find and reuse later.
+To create reusable content, [select one or more blocks](blocks/#selecting-blocks-and-interacting-with-selected-blocks), then open the **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> , select **Turn into**, and choose **Reusable content**. You can also give your block a name to make it easier to find and reuse later.
 
 Alternatively, you can select one or more blocks and then hit **Cmd + C** to open a prompt asking if you want to create reusable content.
 
@@ -59,13 +59,13 @@ If you’re making changes inside a change request, the content will be synced t
 
 ### **Detach reusable content**
 
-You can detach reusable content by opening the **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> and selecting **Detach**. Detaching will convert the content back to regular blocks.
+You can detach reusable content by opening the **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> and selecting **Detach**. Detaching will convert the content back to regular blocks.
 
 Once detached, any changes you make to the block(s) will not be reflected across the other instances, and changes you make in those instances will not be reflected in the detached block(s). All other instances of the reusable content remain synced together.
 
 ### Delete reusable content
 
-You can delete reusable content from your space entirely, if you wish. Find the reusable content in the page’s table of contents, then open the **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> next to the content you’d like to delete, and select **Delete**.
+You can delete reusable content from your space entirely, if you wish. Find the reusable content in the page’s table of contents, then open the **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> next to the content you’d like to delete, and select **Delete**.
 
 Deleting reusable content will **delete it from all pages it is used in**. This action cannot be undone.
 

--- a/creating-content/searching-your-content/README.md
+++ b/creating-content/searching-your-content/README.md
@@ -7,7 +7,7 @@ icon: magnifying-glass
 
 # Searching content
 
-<figure><img src="../../.gitbook/assets/10_01_25_searching_content.svg" alt=""><figcaption><p>Ask questions or search through your content using the built in search bar.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_searching_content.svg" alt="A GitBook screenshot showing the search bar" ><figcaption><p>Ask questions or search through your content using the built in search bar.</p></figcaption></figure>
 
 Whether you’re working within the GitBook app or your visitors are reading your published content, GitBook’s search functions help to make it easy to find what you’re looking for.&#x20;
 

--- a/creating-content/version-control.md
+++ b/creating-content/version-control.md
@@ -17,7 +17,7 @@ In the Version history of a space, you can see a list of all the actions that ch
 
 ### View historical versions of content
 
-To view past versions of your content and see the changes that were made, click the **Version history** <picture><source srcset="../.gitbook/assets/history_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/history_icon_light.svg" alt=""></picture> button in the [space header](../resources/gitbook-ui.md#space-header), or open the **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt=""></picture> next to the space or change request title and choose **Version history**.&#x20;
+To view past versions of your content and see the changes that were made, click the **Version history** <picture><source srcset="../.gitbook/assets/history_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/history_icon_light.svg" alt="The Version history icon in GitBook"></picture> button in the [space header](../resources/gitbook-ui.md#space-header), or open the **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt="The Actions menu icon in GitBook"></picture> next to the space or change request title and choose **Version history**.&#x20;
 
 Click on any item in the list to see how your content looked at the point this change was made. This is very similar to how you view [change requests](../collaboration/change-requests.md).
 
@@ -53,4 +53,4 @@ Add it at the end of your published docs URL as `/~/revisions/<id>`
 
 Rolling back allows you to revert a space’s content to the way it was at a previous point in time. This is helpful if you’ve accidentally made a breaking change or deleted content and need to quickly get back to a previous version of the space.
 
-To roll back to a previous version of your space, hover over the version in the side panel, click the **Actions button** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> and select **Rollback**.
+To roll back to a previous version of your space, hover over the version in the side panel, click the **Actions button** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> and select **Rollback**.

--- a/creating-content/write-and-edit-with-ai.md
+++ b/creating-content/write-and-edit-with-ai.md
@@ -9,7 +9,7 @@ description: Use GitBook AI to generate and build content for your page
 
 You can use GitBook AI to create content on any empty line on your page. It can create all kinds of content — formatted in Markdown — including code samples, templates, page summaries and more.
 
-<figure><img src="../.gitbook/assets/10_01_25_gitbook_ai_writing.svg" alt="A GitBook screenshot showing the AI writing interface" ><figcaption><p>Write with GitBook AI.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_gitbook_ai_writing.svg" alt="A GitBook screenshot showing the AI writing options" ><figcaption><p>Write with GitBook AI.</p></figcaption></figure>
 
 ### Write with GitBook AI
 

--- a/creating-content/write-and-edit-with-ai.md
+++ b/creating-content/write-and-edit-with-ai.md
@@ -9,7 +9,7 @@ description: Use GitBook AI to generate and build content for your page
 
 You can use GitBook AI to create content on any empty line on your page. It can create all kinds of content — formatted in Markdown — including code samples, templates, page summaries and more.
 
-<figure><img src="../.gitbook/assets/10_01_25_gitbook_ai_writing.svg" alt=""><figcaption><p>Write with GitBook AI.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_gitbook_ai_writing.svg" alt="A GitBook screenshot showing the AI writing interface" ><figcaption><p>Write with GitBook AI.</p></figcaption></figure>
 
 ### Write with GitBook AI
 

--- a/getting-started/git-sync/README.md
+++ b/getting-started/git-sync/README.md
@@ -7,7 +7,7 @@ description: >-
 
 # GitHub & GitLab Sync
 
-<figure><img src="../../.gitbook/assets/10_01_25_git_sync.svg" alt=""><figcaption><p>Set up Git Sync for your GitBook space.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_git_sync.svg" alt="A GitBook screenshot showing the Git Sync setup" ><figcaption><p>Set up Git Sync for your GitBook space.</p></figcaption></figure>
 
 ### Overview
 

--- a/getting-started/git-sync/commits.md
+++ b/getting-started/git-sync/commits.md
@@ -28,7 +28,7 @@ Use the following URL format, where `spaceId` corresponds to your space’s URL:
 
 `<https://app.gitbook.com/s/{spaceId}/~/changes/<num>/`
 
-<div data-full-width="false"><figure><img src="../../.gitbook/assets/10_01_25_git_sync_autolink.svg" alt=""><figcaption><p>Autolink setup.</p></figcaption></figure></div>
+<div data-full-width="false"><figure><img src="../../.gitbook/assets/10_01_25_git_sync_autolink.svg" alt="A GitBook screenshot showing autolink setup" ><figcaption><p>Autolink setup.</p></figcaption></figure></div>
 
 ## Customize the commit message template
 

--- a/getting-started/git-sync/enabling-github-sync.md
+++ b/getting-started/git-sync/enabling-github-sync.md
@@ -8,7 +8,7 @@ description: Set up and authorize the GitHub integration for GitBook
 
 In the space you want to sync with your GitHub repo, head to the [space header](../../resources/gitbook-ui.md#space-header) in the top right, and select **Configure**. From the provider list, select **GitHub Sync**.
 
-<figure><img src="../../.gitbook/assets/10_01_25_git_sync_github.svg" alt=""><figcaption><p>GitHub Sync configuration options.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_git_sync_github.svg" alt="A GitBook screenshot showing GitHub Sync configuration options" ><figcaption><p>GitHub Sync configuration options.</p></figcaption></figure>
 
 ### Authenticate with GitHub
 

--- a/getting-started/git-sync/enabling-gitlab-sync.md
+++ b/getting-started/git-sync/enabling-gitlab-sync.md
@@ -8,7 +8,7 @@ description: Set up and authorize the GitLab integration for GitBook
 
 In the space you want to sync with your GitLab repo, head to the space menu in the top right, and select **Synchronize with Git**. From the provider list, select **GitLab Sync**, and click **Configure**.
 
-<figure><img src="../../.gitbook/assets/10_01_25_git_sync-gitlab.svg" alt=""><figcaption><p>GitLab Sync configuration options.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_git_sync-gitlab.svg" alt="A GitBook screenshot showing GitLab Sync configuration options" ><figcaption><p>GitLab Sync configuration options.</p></figcaption></figure>
 
 ### Generate and enter your API access token
 

--- a/getting-started/git-sync/github-pull-request-preview.md
+++ b/getting-started/git-sync/github-pull-request-preview.md
@@ -8,7 +8,7 @@ When you submit a pull request (PR) to a GitHub branch that has been synced to a
 
 You can use this feature to have a final layer of checks before merging a PR, allowing you to see your changes in a non-production environment before merging it into your synced branch.
 
-<figure><img src="../../.gitbook/assets/10_01_25_git_sync_preview.svg" alt="A GitBook screenshot showing a docs preview in a pull request" ><figcaption><p>See a preview of your GitBook site when making a Pull Request.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_git_sync_preview.svg" alt="A screenshot showing a pull request in GitHub for changes to some docs.“ ><figcaption><p>See a preview of your GitBook site when making a Pull Request.</p></figcaption></figure>
 
 ### How to access preview links
 

--- a/getting-started/git-sync/github-pull-request-preview.md
+++ b/getting-started/git-sync/github-pull-request-preview.md
@@ -8,7 +8,7 @@ When you submit a pull request (PR) to a GitHub branch that has been synced to a
 
 You can use this feature to have a final layer of checks before merging a PR, allowing you to see your changes in a non-production environment before merging it into your synced branch.
 
-<figure><img src="../../.gitbook/assets/10_01_25_git_sync_preview.svg" alt=""><figcaption><p>See a preview of your GitBook site when making a Pull Request.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_git_sync_preview.svg" alt="A GitBook screenshot showing a docs preview in a pull request" ><figcaption><p>See a preview of your GitBook site when making a Pull Request.</p></figcaption></figure>
 
 ### How to access preview links
 

--- a/getting-started/import.md
+++ b/getting-started/import.md
@@ -38,11 +38,11 @@ GitBook is Markdown-based, so importing content in Markdown format will yield th
 
 ### The Import panel
 
-<figure><img src="../.gitbook/assets/10_01_25_import_modal.svg" alt=""><figcaption><p>The import panel in GitBook.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_import_modal.svg" alt="A GitBook screenshot showing the import panel" ><figcaption><p>The import panel in GitBook.</p></figcaption></figure>
 
 When you create a new space, you’ll have the option to import content from the bottom sheet of the first empty page.
 
-Alternatively, you can always import a page or subpage by selecting **New page** > **Import new pages** in the [table of contents](../resources/gitbook-ui.md#table-of-contents), or opening the Actions menu <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> for a page and choosing **Import subpages**.
+Alternatively, you can always import a page or subpage by selecting **New page** > **Import new pages** in the [table of contents](../resources/gitbook-ui.md#table-of-contents), or opening the Actions menu <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> for a page and choosing **Import subpages**.
 
 After choosing an input source, you can select the file you’d like to import.
 

--- a/getting-started/quickstart.md
+++ b/getting-started/quickstart.md
@@ -15,7 +15,7 @@ You’ll need a GitBook account to start publishing documentation.
 
 When you first sign up, you’ll have a chance to create a docs site from the docs site wizard. You can launch the wizard again to create a new site at any point by clicking the **+** button next to the **Docs sites** header in the sidebar.
 
-<figure><img src="../.gitbook/assets/10_01_25_site_wizard.svg" alt="A GitBook screenshot showing the docs site wizard" ><figcaption><p>Publish your first site in just a few minutes using the docs site wizard.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_site_wizard.svg" alt="A GitBook screenshot showing the publishing step of the docs site wizard" ><figcaption><p>Publish your first site in just a few minutes using the docs site wizard.</p></figcaption></figure>
 
 The docs site wizard will take you through the flow of creating your first site. You’ll need to give your site a name, choose if you want to start from scratch with an empty site or add our sample content, and whether or not you want to publish your docs right away.
 

--- a/getting-started/quickstart.md
+++ b/getting-started/quickstart.md
@@ -15,7 +15,7 @@ You’ll need a GitBook account to start publishing documentation.
 
 When you first sign up, you’ll have a chance to create a docs site from the docs site wizard. You can launch the wizard again to create a new site at any point by clicking the **+** button next to the **Docs sites** header in the sidebar.
 
-<figure><img src="../.gitbook/assets/10_01_25_site_wizard.svg" alt=""><figcaption><p>Publish your first site in just a few minutes using the docs site wizard.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_site_wizard.svg" alt="A GitBook screenshot showing the docs site wizard" ><figcaption><p>Publish your first site in just a few minutes using the docs site wizard.</p></figcaption></figure>
 
 The docs site wizard will take you through the flow of creating your first site. You’ll need to give your site a name, choose if you want to start from scratch with an empty site or add our sample content, and whether or not you want to publish your docs right away.
 

--- a/help/connectivity-issues.md
+++ b/help/connectivity-issues.md
@@ -54,4 +54,4 @@ Here are a few possible causes for your connectivity issues:
 Please always check [our status page](https://www.gitbookstatus.com/) to see if there are any outages to our app or the third-party services we rely on.
 {% endhint %}
 
-If everything fails, please share the details with <img src="../.gitbook/assets/gitbook-support.png" alt="" data-size="line"> [GitBook Support](mailto:support@gitbook.com).
+If everything fails, please share the details with <img src="../.gitbook/assets/gitbook-support.png" alt="An icon showing the GitBook Support logo" data-size="line"> [GitBook Support](mailto:support@gitbook.com).

--- a/integrations/install-an-integration.md
+++ b/integrations/install-an-integration.md
@@ -27,7 +27,7 @@ Next, click on the integration you want to install. Certain integrations work ca
 
 On this screen you can select the areas you would like to install your integration in.
 
-<figure><img src="../.gitbook/assets/10_01_25_install_integration.svg" alt="A GitBook screenshot showing where to install an integration" ><figcaption><p>Choose an area to install an integration in.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_install_integration.svg" alt="A GitBook screenshot showing where you can install an integration" ><figcaption><p>Choose an area to install an integration in.</p></figcaption></figure>
 
 #### 3. Configure your integration
 

--- a/integrations/install-an-integration.md
+++ b/integrations/install-an-integration.md
@@ -13,7 +13,7 @@ You can install an integration in a single space, multiple spaces, or all the sp
 
 If you install an integration in a single space, it will only work in that specific space. By installing an integration in multiple spaces, you’ll be able to perform actions across all those spaces.
 
-<figure><img src="../.gitbook/assets/10_01_25_integrations.svg" alt=""><figcaption><p>Browse GitBook's built in integration library.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_integrations.svg" alt="A GitBook screenshot showing the integration library" ><figcaption><p>Browse GitBook's built in integration library.</p></figcaption></figure>
 
 ### Install an integration in your organization
 
@@ -27,7 +27,7 @@ Next, click on the integration you want to install. Certain integrations work ca
 
 On this screen you can select the areas you would like to install your integration in.
 
-<figure><img src="../.gitbook/assets/10_01_25_install_integration.svg" alt=""><figcaption><p>Choose an area to install an integration in.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_install_integration.svg" alt="A GitBook screenshot showing where to install an integration" ><figcaption><p>Choose an area to install an integration in.</p></figcaption></figure>
 
 #### 3. Configure your integration
 

--- a/integrations/integrations-beta/github-entities.md
+++ b/integrations/integrations-beta/github-entities.md
@@ -47,25 +47,25 @@ To configure the GitHub Entities integration, you’ll need to both authenticate
 
 1. **Install the GitHub Entities integration in GitBook**
 
-<figure><img src="../../.gitbook/assets/Screenshot 2023-10-11 at 13.34.39.png" alt=""><figcaption><p>Install the GitHub Entities integration</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screenshot 2023-10-11 at 13.34.39.png" alt="A GitBook screenshot showing how to install the GitHub Entities integration" ><figcaption><p>Install the GitHub Entities integration</p></figcaption></figure>
 
 2. **Install the GitBook Entities app to GitHub**
 
 To configure the GitHub Entities integration correctly, you’ll need to [install the GitBook Entities](https://github.com/apps/gitbook-entities/) app into your GitHub Account.
 
-<figure><img src="../../.gitbook/assets/Screenshot 2023-10-11 at 13.34.45.png" alt=""><figcaption><p>Install the GitBook Entities ap to GitHub</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screenshot 2023-10-11 at 13.34.45.png" alt="A GitBook screenshot showing installation of the GitBook Entities app on GitHub" ><figcaption><p>Install the GitBook Entities ap to GitHub</p></figcaption></figure>
 
 3. **Select the repositories you want to sync**
 
-<figure><img src="../../.gitbook/assets/Screenshot 2023-10-05 at 11.17.54.png" alt=""><figcaption><p>Select repositories to index</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screenshot 2023-10-05 at 11.17.54.png" alt="A GitBook screenshot showing repository selection" ><figcaption><p>Select repositories to index</p></figcaption></figure>
 
 4. **Authenticate your GitHub Account**
 
-<figure><img src="../../.gitbook/assets/Screenshot 2023-10-11 at 13.36.09.png" alt=""><figcaption><p>Authenticate your GitHub account</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screenshot 2023-10-11 at 13.36.09.png" alt="A GitBook screenshot showing GitHub authentication" ><figcaption><p>Authenticate your GitHub account</p></figcaption></figure>
 
 5. **Select your account in the GitBook integration’s configuration**
 
-<figure><img src="../../.gitbook/assets/Screenshot 2023-10-11 at 15.35.42.png" alt=""><figcaption><p>Select your GitHub account</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screenshot 2023-10-11 at 15.35.42.png" alt="A GitBook screenshot showing account selection" ><figcaption><p>Select your GitHub account</p></figcaption></figure>
 
 {% hint style="warning" %}
 GitHub Entities will index any and all of the repositories you grant it access to. If you’d only like to index a select few repositories, make sure to configure them as you see in step 3 above.

--- a/product-tour/git-sync/monorepos.md
+++ b/product-tour/git-sync/monorepos.md
@@ -6,7 +6,7 @@ GitBook can synchronize multiple directories from the same repository with multi
 
 <div data-full-width="true">
 
-<figure><img src="../../.gitbook/assets/monorepo.png" alt=""><figcaption><p>Monorepo preview</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/monorepo.png" alt="A GitBook screenshot showing a monorepo preview" ><figcaption><p>Monorepo preview</p></figcaption></figure>
 
 </div>
 

--- a/product-tour/navigation.md
+++ b/product-tour/navigation.md
@@ -154,7 +154,7 @@ Page actions are located next to the page title. The type of actions available w
 
 <div align="center" data-full-width="true">
 
-<figure><img src="../.gitbook/assets/page-options.png" alt=""><figcaption><p>Page options menu</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/page-options.png" alt="A GitBook screenshot showing the Page options menu" ><figcaption><p>Page options menu</p></figcaption></figure>
 
 </div>
 

--- a/product-tour/searching-your-content/lens.md
+++ b/product-tour/searching-your-content/lens.md
@@ -40,7 +40,7 @@ Then, click on the GitBook AI tab. You’ll see a number of suggested questions 
 
 <div data-full-width="true">
 
-<figure><img src="../../.gitbook/assets/search-lens-tab.png" alt=""><figcaption><p>Ask a question with GitBook AI.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/search-lens-tab.png" alt="A GitBook screenshot showing the Ask or search bar" ><figcaption><p>Ask a question with GitBook AI.</p></figcaption></figure>
 
 </div>
 
@@ -48,7 +48,7 @@ For this example, lets try: "What makes change requests a powerful GitBook featu
 
 <div data-full-width="true">
 
-<figure><img src="../../.gitbook/assets/search-lens-answer.png" alt=""><figcaption><p>GitBook AI gives you a semantic answer to your question.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/search-lens-answer.png" alt="A GitBook screenshot showing a GitBook AI answer" ><figcaption><p>GitBook AI gives you a semantic answer to your question.</p></figcaption></figure>
 
 </div>
 

--- a/product-tour/sso-and-saml/saml/README.md
+++ b/product-tour/sso-and-saml/saml/README.md
@@ -24,7 +24,7 @@ After configuring SSO on your IdP, you will be able to enter metadata. When the 
 
 <div data-full-width="true">
 
-<img src="../../../.gitbook/assets/SAML.png" alt="">
+<img src="../../../.gitbook/assets/SAML.png" alt="A GitBook screenshot showing SAML provider setup">
 
 </div>
 
@@ -41,7 +41,7 @@ Most SAML 2.0 compliant identity providers require the same information about th
 
 <div data-full-width="true">
 
-<img src="../../../.gitbook/assets/SAML Service Info.png" alt="">
+<img src="../../../.gitbook/assets/SAML Service Info.png" alt="A GitBook screenshot showing SAML service information">
 
 </div>
 

--- a/product-tour/sso-and-saml/saml/sso-members-vs-non-sso.md
+++ b/product-tour/sso-and-saml/saml/sso-members-vs-non-sso.md
@@ -4,7 +4,7 @@ Users who have created a GitBook account with an email used in your SAML Identit
 
 <div data-full-width="true">
 
-<figure><img src="../../../.gitbook/assets/SSO-vs-nonSSO.png" alt=""><figcaption><p>Login with SSO screen </p></figcaption></figure>
+<figure><img src="../../../.gitbook/assets/SSO-vs-nonSSO.png" alt="A GitBook screenshot showing the login with SSO screen" ><figcaption><p>Login with SSO screen </p></figcaption></figure>
 
 </div>
 
@@ -41,6 +41,6 @@ to Organization administrators can enable SSO login for members by linking their
 
 <div data-full-width="true">
 
-<figure><img src="../../../.gitbook/assets/sso.gif" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../../.gitbook/assets/sso.gif" alt="A GitBook screenshot showing the SSO user flow" ><figcaption></figcaption></figure>
 
 </div>

--- a/publishing-documentation/adaptive-content/README.md
+++ b/publishing-documentation/adaptive-content/README.md
@@ -16,7 +16,7 @@ Adaptive content helps to build a tailored documentation experience based on who
 Adaptive content is slightly different from [authenticated access](../authenticated-access/), although they can work together. While authenticated access allows you to protect your docs through a login, adaptive content customizes published material based on various authentication methods — including authenticated access or those from your own app.
 {% endhint %}
 
-<figure><img src="../../.gitbook/assets/21_03_25_adaptive_content (1).svg" alt=""><figcaption><p>Enable adaptive content on a page, variant, or section.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_03_25_adaptive_content (1).svg" alt="A GitBook screenshot showing adaptive content controls" ><figcaption><p>Enable adaptive content on a page, variant, or section.</p></figcaption></figure>
 
 ### How it works
 

--- a/publishing-documentation/adaptive-content/adapting-your-content.md
+++ b/publishing-documentation/adaptive-content/adapting-your-content.md
@@ -38,19 +38,19 @@ You can combine multiple claims into the condition editor to match specific user
 
 ### Conditional pages
 
-To launch the condition editor for a page, head to the actions menu <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> next to a page, and click “**Add condition**”. You can also launch the condition editor from a [page’s options](../../resources/gitbook-ui.md#page-options).
+To launch the condition editor for a page, head to the actions menu <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> next to a page, and click “**Add condition**”. You can also launch the condition editor from a [page’s options](../../resources/gitbook-ui.md#page-options).
 
-You can see which pages in your space have conditions set if the page has a page condition icon <picture><source srcset="../../.gitbook/assets/page-condition - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/page-condition.svg" alt=""></picture> next to it.
+You can see which pages in your space have conditions set if the page has a page condition icon <picture><source srcset="../../.gitbook/assets/page-condition - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/page-condition.svg" alt="The Page condition icon in GitBook"></picture> next to it.
 
 ### Conditional variants
 
-To launch the condition editor for a variant, head to the actions menu <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> next to a variant, and click “**Add condition**”.
+To launch the condition editor for a variant, head to the actions menu <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> next to a variant, and click “**Add condition**”.
 
-You can see which variants in your docs have conditions set if the variant has a page condition icon <picture><source srcset="../../.gitbook/assets/page-condition - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/page-condition.svg" alt=""></picture> next to it.
+You can see which variants in your docs have conditions set if the variant has a page condition icon <picture><source srcset="../../.gitbook/assets/page-condition - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/page-condition.svg" alt="The Page condition icon in GitBook"></picture> next to it.
 
 ### Conditional sections
 
-To launch the condition editor for a section, head to the actions menu <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> next to a section, and click “**Add condition**”.
+To launch the condition editor for a section, head to the actions menu <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> next to a section, and click “**Add condition**”.
 
-You can see which sections in your docs have conditions set if the section has a page condition icon <picture><source srcset="../../.gitbook/assets/page-condition - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/page-condition.svg" alt=""></picture> next to it.
+You can see which sections in your docs have conditions set if the section has a page condition icon <picture><source srcset="../../.gitbook/assets/page-condition - dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/page-condition.svg" alt="The Page condition icon in GitBook"></picture> next to it.
 

--- a/publishing-documentation/adaptive-content/enabling-adaptive-content.md
+++ b/publishing-documentation/adaptive-content/enabling-adaptive-content.md
@@ -12,7 +12,7 @@ Before you’re able to pass user data to GitBook, you’ll need to configure yo
 
 Head to your [site’s settings](../site-settings.md), and enable “Adaptive content” from your site’s audience settings. Once enabled, you’ll get a generated “Visitor token signing key”, which you’ll need in order to continue the adaptive content setup.
 
-<figure><img src="../../.gitbook/assets/21_03_25_enable_adaptive_content.svg" alt=""><figcaption><p>Enable adaptive content</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_03_25_enable_adaptive_content.svg" alt="A GitBook screenshot showing the enable adaptive content toggle" ><figcaption><p>Enable adaptive content</p></figcaption></figure>
 
 ### Set your adaptive schema
 

--- a/publishing-documentation/adaptive-content/testing-with-segments.md
+++ b/publishing-documentation/adaptive-content/testing-with-segments.md
@@ -8,11 +8,11 @@ Segments allow you to test the conditions you set by defining claims on a mock u
 
 For example, you might want to only show a page or section to beta users. By creating a segment and defining the properties associated with this group of mock users, you can mimic a segment that is specific to the users you’re targeting.
 
-<figure><img src="../../.gitbook/assets/21_03_25_segment_editor.svg" alt=""><figcaption><p>The segment editor in GitBook.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_03_25_segment_editor.svg" alt="A GitBook screenshot showing the segment editor" ><figcaption><p>The segment editor in GitBook.</p></figcaption></figure>
 
 ### Create a segment
 
-To create a new segment, head to the condition editor, and click the settings icon <picture><source srcset="../../.gitbook/assets/settings_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/settings_icon_light.svg" alt=""></picture> next to an existing segment in the segment dropdown.
+To create a new segment, head to the condition editor, and click the settings icon <picture><source srcset="../../.gitbook/assets/settings_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/settings_icon_light.svg" alt="The Settings icon in GitBook"></picture> next to an existing segment in the segment dropdown.
 
 Here you’ll be able to define the data that will appear on a mock user. Because this is the data that’s being represented, the `visitor.claims` key is omitted.
 
@@ -28,7 +28,7 @@ To create a segment for beta users following the examples in our docs, you would
 
 When heading back to the condition editor, selecting the beta segment we created should show that the page we’re viewing **would** be accessible to our test user.
 
-<figure><img src="../../.gitbook/assets/21_03_25_testing_segments.svg" alt=""><figcaption><p>Testing a segment in GitBook.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_03_25_testing_segments.svg" alt="A GitBook screenshot showing how to test a segment" ><figcaption><p>Testing a segment in GitBook.</p></figcaption></figure>
 
 ### Detected segments
 

--- a/publishing-documentation/authenticated-access/README.md
+++ b/publishing-documentation/authenticated-access/README.md
@@ -9,7 +9,7 @@ icon: key
 
 Authenticated access allows you to publish your content while requiring authentication from any visitors who want to view it. When enabled, GitBook lets your authentication provider handle who has access to the content.
 
-<figure><img src="../../.gitbook/assets/10_01_25_visitor_authentication.svg" alt=""><figcaption><p>Add a sign in to your published documentation.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_visitor_authentication.svg" alt="A GitBook screenshot showing how to add visitor authentication" ><figcaption><p>Add a sign in to your published documentation.</p></figcaption></figure>
 
 ### Use cases
 

--- a/publishing-documentation/authenticated-access/README.md
+++ b/publishing-documentation/authenticated-access/README.md
@@ -9,7 +9,7 @@ icon: key
 
 Authenticated access allows you to publish your content while requiring authentication from any visitors who want to view it. When enabled, GitBook lets your authentication provider handle who has access to the content.
 
-<figure><img src="../../.gitbook/assets/10_01_25_visitor_authentication.svg" alt="A GitBook screenshot showing how to add visitor authentication" ><figcaption><p>Add a sign in to your published documentation.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_visitor_authentication.svg" alt="A screenshot showing a login screen for docs behind authenticated access" ><figcaption><p>Add a sign in to your published documentation.</p></figcaption></figure>
 
 ### Use cases
 

--- a/publishing-documentation/authenticated-access/setting-up-a-custom-backend.md
+++ b/publishing-documentation/authenticated-access/setting-up-a-custom-backend.md
@@ -111,7 +111,7 @@ For instance, if your login screen is located at `https://example.com/login`, yo
 
 You can configure this fallback URL within your site’s audience settings under the "Authenticated access" tab.
 
-<figure><img src="../../.gitbook/assets/Screenshot 2025-03-25 at 15.00.08.png" alt=""><figcaption><p>Configure a fallback URL</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screenshot 2025-03-25 at 15.00.08.png" alt="A GitBook screenshot showing where to configure a fallback URL" ><figcaption><p>Configure a fallback URL</p></figcaption></figure>
 
 When redirecting to the fallback URL, GitBook includes a `location` query parameter to the fallback URL that you can leverage in your handler to redirect the user to the original location of the user:
 

--- a/publishing-documentation/authenticated-access/setting-up-auth0.md
+++ b/publishing-documentation/authenticated-access/setting-up-auth0.md
@@ -35,11 +35,11 @@ Configure Auth0 to work with adaptive content in GitBook.
 First, sign in to Auth0 platform and create a new application (or use an existing one) by clicking the Applications button in the left sidebar. If creating a new application, name it appropriately and choose "Regular Web Application" as the option. Click Create. You may need to be admin to follow along this guide.\
 
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-25 at 4.52.25 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-25 at 4.52.25 PM.png" alt="A GitBook screenshot showing the Auth0 quickstart panel" ><figcaption></figcaption></figure>
 
 A quickstart panel will show up. Select Node.js (Express) option and then select "I want to integrate my app."  You will see a screen prompting you to configure Auth0. It should look like the image below
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-25 at 4.54.42 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-25 at 4.54.42 PM.png" alt="A GitBook screenshot showing the Auth0 configuration screen" ><figcaption></figcaption></figure>
 
 Click on Save Settings And Continue.
 
@@ -51,19 +51,19 @@ We will need these to configure our Auth0 authenticated access Integration.
 Please ensure at least one connection is enabled for your Auth0 application.
 {% endhint %}
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-05-28 at 5.00.39 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-05-28 at 5.00.39 PM.png" alt="A GitBook screenshot showing Auth0 settings with domain and client details" ><figcaption></figcaption></figure>
 
 ### Install and configure the Auth0 integration
 
 Navigate to the Integrations tab in a site and locate the Auth0 integration or navigate directly to this [https://app.gitbook.com/integrations/VA-Auth0](https://app.gitbook.com/integrations/VA-Auth0).
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.21.30 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.21.30 PM.png" alt="A GitBook screenshot showing the Auth0 integration page" ><figcaption></figcaption></figure>
 
 Install the integration on your site.
 
 Upon installation on site, you will see a modal asking you enter the Client ID, Auth0 Domain, and Client Secret.
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.22.52 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.22.52 PM.png" alt="A GitBook screenshot showing the Auth0 credentials modal" ><figcaption></figcaption></figure>
 
 For Client ID and Client Secret, paste in the value you copied from Auth0 Dashboard. For Auth0 Domain, enter the Domain copied from Auth0 (make sure to prefix it with `https://`) .
 

--- a/publishing-documentation/authenticated-access/setting-up-auth0.md
+++ b/publishing-documentation/authenticated-access/setting-up-auth0.md
@@ -32,14 +32,14 @@ Configure Auth0 to work with adaptive content in GitBook.
 
 ### Create a new Auth0 application
 
-First, sign in to Auth0 platform and create a new application (or use an existing one) by clicking the Applications button in the left sidebar. If creating a new application, name it appropriately and choose "Regular Web Application" as the option. Click Create. You may need to be admin to follow along this guide.\
+First, sign in to Auth0 platform and create a new application (or use an existing one) by clicking the Applications button in the left sidebar. If creating a new application, name it appropriately and choose "Regular Web Application" as the option. Click Create. You may need to be admin to follow along this guide.
 
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-25 at 4.52.25 PM.png" alt="A GitBook screenshot showing the Auth0 quickstart panel" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-25 at 4.52.25 PM.png" alt="An Auth0 screenshot showing the quickstart panel" ><figcaption></figcaption></figure>
 
 A quickstart panel will show up. Select Node.js (Express) option and then select "I want to integrate my app."  You will see a screen prompting you to configure Auth0. It should look like the image below
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-25 at 4.54.42 PM.png" alt="A GitBook screenshot showing the Auth0 configuration screen" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-25 at 4.54.42 PM.png" alt="An Auth0 screenshot showing the Node.js Express configuration screen" ><figcaption></figcaption></figure>
 
 Click on Save Settings And Continue.
 
@@ -51,13 +51,13 @@ We will need these to configure our Auth0 authenticated access Integration.
 Please ensure at least one connection is enabled for your Auth0 application.
 {% endhint %}
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-05-28 at 5.00.39 PM.png" alt="A GitBook screenshot showing Auth0 settings with domain and client details" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-05-28 at 5.00.39 PM.png" alt="An Auth0 screenshot showing settings with domain and client details" ><figcaption></figcaption></figure>
 
 ### Install and configure the Auth0 integration
 
 Navigate to the Integrations tab in a site and locate the Auth0 integration or navigate directly to this [https://app.gitbook.com/integrations/VA-Auth0](https://app.gitbook.com/integrations/VA-Auth0).
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.21.30 PM.png" alt="A GitBook screenshot showing the Auth0 integration page" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.21.30 PM.png" alt="A GitBook screenshot showing the site settings page" ><figcaption></figcaption></figure>
 
 Install the integration on your site.
 

--- a/publishing-documentation/authenticated-access/setting-up-aws-cognito.md
+++ b/publishing-documentation/authenticated-access/setting-up-aws-cognito.md
@@ -48,7 +48,7 @@ Click on the created app client and make a note of the Client ID and Client Secr
 
 Navigate to integrations within the GitBook app, select authenticated access as the category, and install the AWS Cognito integration.
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.37.39 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.37.39 PM.png" alt="A GitBook screenshot showing the AWS Cognito integration install screen" ><figcaption></figcaption></figure>
 
 
 
@@ -58,7 +58,7 @@ Open up the Cognito integration's configuration screen for the space you install
 
 It should look like the following image:
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.41.57 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.41.57 PM.png" alt="A GitBook screenshot showing the AWS Cognito configuration screen" ><figcaption></figcaption></figure>
 
 For Client ID, Cognito Domain, and Client Secret, paste in the values you got from Cognito.
 

--- a/publishing-documentation/authenticated-access/setting-up-azure-ad.md
+++ b/publishing-documentation/authenticated-access/setting-up-azure-ad.md
@@ -50,19 +50,19 @@ Start by creating an app registration in your Microsoft Entra ID dashboard. This
 6.  Click **Register** to complete the app registration.\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_integration_register_app.png" alt="A GitBook screenshot showing how to register an Azure AD app" ><figcaption><p>Register an app for the GitBook VA integration.</p></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_integration_register_app.png" alt="An Azure screenshot showing how to register an Azure AD app" ><figcaption><p>Register an app for the GitBook VA integration.</p></figcaption></figure>
 
 
 7.  You should then see your new app registration **Overview** screen. Copy and make note of the **Application (client) ID** and **Directory (tenant) ID**.\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_integration_app_reg_overview.png" alt="A GitBook screenshot showing the app registration overview" ><figcaption><p>Overview of the newly created app registration.</p></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_integration_app_reg_overview.png" alt="An Azure screenshot showing the app registration overview" ><figcaption><p>Overview of the newly created app registration.</p></figcaption></figure>
 
 
 8.  Click on **Add a certificate or secret**. You should see the following **Certificates & Secrets** screen:\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_integration_client_secrets.png" alt="A GitBook screenshot showing where to add a certificate or secret" ><figcaption><p>Add a certificate or secret.</p></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_integration_client_secrets.png" alt="An Azure screenshot showing where to add a certificate or secret" ><figcaption><p>Add a certificate or secret.</p></figcaption></figure>
 
 
 9. Click on **+ New client secret**.
@@ -77,7 +77,7 @@ Once you've created the Azure AD app registration, the next step is to install t
 2.  Click on the **Integrations** button in the top right from your site’s settings.\
 
 
-    <figure><img src="../../.gitbook/assets/va_site_integration_overview_screen.png" alt="A GitBook screenshot showing the site integration overview" ><figcaption></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/va_site_integration_overview_screen.png" alt="A GitBook screenshot showing the site settings overview" ><figcaption></figcaption></figure>
 
 
 3. Click on **Authenticated Access** from the categories in the sidebar.
@@ -97,11 +97,11 @@ Once you've created the Azure AD app registration, the next step is to install t
 11. Click **+ Add a platform** and select **Web** card in the panel that opens.\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_app_reg_authentication.png" alt="A GitBook screenshot showing authentication platform settings" ><figcaption></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_app_reg_authentication.png" alt="An Azure screenshot showing authentication platform settings" ><figcaption></figcaption></figure>
 12. Paste the GitBook integration **URL** you copied earlier in the **Redirect URI** field, and click “Configure”\
 
 
-    <figure><img src="../../.gitbook/assets/image.png" alt="A GitBook screenshot showing where to enter the redirect URI" ><figcaption></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/image.png" alt="An Azure screenshot showing where to enter the redirect URI" ><figcaption></figcaption></figure>
 
 
 13. Head back to **Azure integration** installation screen **in GitBook**.

--- a/publishing-documentation/authenticated-access/setting-up-azure-ad.md
+++ b/publishing-documentation/authenticated-access/setting-up-azure-ad.md
@@ -50,19 +50,19 @@ Start by creating an app registration in your Microsoft Entra ID dashboard. This
 6.  Click **Register** to complete the app registration.\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_integration_register_app.png" alt=""><figcaption><p>Register an app for the GitBook VA integration.</p></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_integration_register_app.png" alt="A GitBook screenshot showing how to register an Azure AD app" ><figcaption><p>Register an app for the GitBook VA integration.</p></figcaption></figure>
 
 
 7.  You should then see your new app registration **Overview** screen. Copy and make note of the **Application (client) ID** and **Directory (tenant) ID**.\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_integration_app_reg_overview.png" alt=""><figcaption><p>Overview of the newly created app registration.</p></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_integration_app_reg_overview.png" alt="A GitBook screenshot showing the app registration overview" ><figcaption><p>Overview of the newly created app registration.</p></figcaption></figure>
 
 
 8.  Click on **Add a certificate or secret**. You should see the following **Certificates & Secrets** screen:\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_integration_client_secrets.png" alt=""><figcaption><p>Add a certificate or secret.</p></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_integration_client_secrets.png" alt="A GitBook screenshot showing where to add a certificate or secret" ><figcaption><p>Add a certificate or secret.</p></figcaption></figure>
 
 
 9. Click on **+ New client secret**.
@@ -77,7 +77,7 @@ Once you've created the Azure AD app registration, the next step is to install t
 2.  Click on the **Integrations** button in the top right from your site’s settings.\
 
 
-    <figure><img src="../../.gitbook/assets/va_site_integration_overview_screen.png" alt=""><figcaption></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/va_site_integration_overview_screen.png" alt="A GitBook screenshot showing the site integration overview" ><figcaption></figcaption></figure>
 
 
 3. Click on **Authenticated Access** from the categories in the sidebar.
@@ -85,11 +85,11 @@ Once you've created the Azure AD app registration, the next step is to install t
 5.  Click **Install on this site**.\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_install_on_site_screen.png" alt=""><figcaption></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_install_on_site_screen.png" alt="A GitBook screenshot showing installation of the Azure AD integration" ><figcaption></figcaption></figure>
 6.  After installing the integration on your site, you should see the integration's configuration screen:\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_config_dialog.png" alt=""><figcaption></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_config_dialog.png" alt="A GitBook screenshot showing the Azure AD configuration dialog" ><figcaption></figcaption></figure>
 7. Enter the **Client ID**, **Tenant ID**, and **Client Secret** values you copied after [creating the Azure AD app registration](setting-up-azure-ad.md#id-1.-create-an-app-registration-in-azure-a-d) earlier, and click “Save”.
 8. Copy the **URL** displayed **at the bottom of the dialog**.
 9. Head back to the Azure AD app registration you created earlier in the Microsoft Entra ID dashboard.
@@ -97,11 +97,11 @@ Once you've created the Azure AD app registration, the next step is to install t
 11. Click **+ Add a platform** and select **Web** card in the panel that opens.\
 
 
-    <figure><img src="../../.gitbook/assets/azure_ad_app_reg_authentication.png" alt=""><figcaption></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/azure_ad_app_reg_authentication.png" alt="A GitBook screenshot showing authentication platform settings" ><figcaption></figcaption></figure>
 12. Paste the GitBook integration **URL** you copied earlier in the **Redirect URI** field, and click “Configure”\
 
 
-    <figure><img src="../../.gitbook/assets/image.png" alt=""><figcaption></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/image.png" alt="A GitBook screenshot showing where to enter the redirect URI" ><figcaption></figcaption></figure>
 
 
 13. Head back to **Azure integration** installation screen **in GitBook**.
@@ -111,7 +111,7 @@ Once you've created the Azure AD app registration, the next step is to install t
 17. Click **Update audience**.\
 
 
-    <figure><img src="../../.gitbook/assets/Screenshot 2025-03-24 at 18.41.45.png" alt=""><figcaption></figcaption></figure>
+    <figure><img src="../../.gitbook/assets/Screenshot 2025-03-24 at 18.41.45.png" alt="A GitBook screenshot showing authenticated access settings" ><figcaption></figcaption></figure>
 18. Head to the site's overview screen and click **Publish** if the site is not already published. &#x20;
 
 \

--- a/publishing-documentation/authenticated-access/setting-up-oidc.md
+++ b/publishing-documentation/authenticated-access/setting-up-oidc.md
@@ -37,7 +37,7 @@ There are some things that you need to set up on your Identity Provider in order
 You need to create a new app inside your Identity Provider. Its type should be "Web Application." In Google, you create these under "API and Services", "Credentials", and then under "OAuth 2.0 Client IDs."\
 
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-05-15 at 11.19.59 AM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-05-15 at 11.19.59 AM.png" alt="A GitBook screenshot showing creation of an OAuth client" ><figcaption></figcaption></figure>
 
 Click on Create Credentials, select OAuth Client ID, select Web Application as the type, name it appropriately, and under Authorized Redirect URIs, enter the Callback URL you got from GitBook.
 
@@ -47,7 +47,7 @@ Click Create. Make a note of the Client ID and Client Secret. We will need these
 
 Navigate to integrations within the GitBook app, select authenticated access as the category, and install the OIDC integration. Install the OIDC integration on your chosen docs site.
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.37.39 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.37.39 PM.png" alt="A GitBook screenshot showing the OIDC integration installation" ><figcaption></figcaption></figure>
 
 Once you've installed it on your site, go to configuration and make a note of the Callback URL right above the Save button. We may need it to set up the Identity Provider.&#x20;
 
@@ -55,7 +55,7 @@ Open up the OIDC integration's configuration screen for the space you installed 
 
 It should look like the following image
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.38.30 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.38.30 PM.png" alt="A GitBook screenshot showing the OIDC configuration screen" ><figcaption></figcaption></figure>
 
 
 

--- a/publishing-documentation/authenticated-access/setting-up-oidc.md
+++ b/publishing-documentation/authenticated-access/setting-up-oidc.md
@@ -37,7 +37,7 @@ There are some things that you need to set up on your Identity Provider in order
 You need to create a new app inside your Identity Provider. Its type should be "Web Application." In Google, you create these under "API and Services", "Credentials", and then under "OAuth 2.0 Client IDs."\
 
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-05-15 at 11.19.59 AM.png" alt="A GitBook screenshot showing creation of an OAuth client" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-05-15 at 11.19.59 AM.png" alt="A screenshot showing creation of an OAuth client in an identity provider" ><figcaption></figcaption></figure>
 
 Click on Create Credentials, select OAuth Client ID, select Web Application as the type, name it appropriately, and under Authorized Redirect URIs, enter the Callback URL you got from GitBook.
 

--- a/publishing-documentation/authenticated-access/setting-up-okta.md
+++ b/publishing-documentation/authenticated-access/setting-up-okta.md
@@ -34,17 +34,17 @@ Configure Okta to work with adaptive content in GitBook.
 
 First, sign in to Okta platform (the admin version) and create a new app integration (or use an existing one) by clicking the Applications button in the left sidebar.&#x20;
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 1.32.55 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 1.32.55 PM.png" alt="A GitBook screenshot showing the Okta create app integration screen" ><figcaption></figcaption></figure>
 
 Click Create App Integration and select OIDC - OpenID Connect as the Sign-In method. And then select Web Application as the application type.
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 1.39.15 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 1.39.15 PM.png" alt="A GitBook screenshot showing the Okta integration setup" ><figcaption></figcaption></figure>
 
 Name it appropriately and don't edit any other setting on that page. For assignments, choose the appropriate checkbox. Click Save.
 
 On the next screen, copy Client ID and Client Secret. Copy the Okta Domain right below your email address by clicking the dropdown in the top right.&#x20;
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 4.52.14 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 4.52.14 PM.png" alt="A GitBook screenshot showing where to copy client credentials" ><figcaption></figcaption></figure>
 
 We will need these values to configure the Okta Integration.
 
@@ -52,13 +52,13 @@ We will need these values to configure the Okta Integration.
 
 Navigate to the Integrations tab in the site you want to publish and locate the Okta integration or navigate directly to this [https://app.gitbook.com/integrations/VA-Okta](https://app.gitbook.com/o/d8f63b60-89ae-11e7-8574-5927d48c4877/s/zq8ynchcecIscc4uulgN/).
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.21.30 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.21.30 PM.png" alt="A GitBook screenshot showing the Okta integration page" ><figcaption></figcaption></figure>
 
 Install the integration on your site.
 
 Upon installation on site, you will see a screen asking you enter the Client ID, Okta Domain, and Client Secret.
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.34.37 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.34.37 PM.png" alt="A GitBook screenshot showing the Okta credentials modal" ><figcaption></figcaption></figure>
 
 For Client ID, Okta Domain (remove `https://`prefix, if any)  and Client Secret, paste in the value you copied from Okta Dashboard.&#x20;
 
@@ -66,7 +66,7 @@ Click Save.
 
 Copy the URL displayed in the modal and enter it as a Sign-In redirect URI in Okta (as shown in the below screenshot). Hit Save.
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-01-14 at 7.55.08 PM.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-01-14 at 7.55.08 PM.png" alt="A GitBook screenshot showing the sign-in redirect URI configuration" ><figcaption></figcaption></figure>
 
 Now, in GitBook, close the integrations modal and click on the Manage site button. Navigate to **Audience**, select **Authenticated access**, and choose Okta as the backend. Then, click **Update audience**. Go to the site’s screen and click **Publish**.\
 \

--- a/publishing-documentation/authenticated-access/setting-up-okta.md
+++ b/publishing-documentation/authenticated-access/setting-up-okta.md
@@ -34,17 +34,17 @@ Configure Okta to work with adaptive content in GitBook.
 
 First, sign in to Okta platform (the admin version) and create a new app integration (or use an existing one) by clicking the Applications button in the left sidebar.&#x20;
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 1.32.55 PM.png" alt="A GitBook screenshot showing the Okta create app integration screen" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 1.32.55 PM.png" alt="An Okta screenshot showing the create app integration screen" ><figcaption></figcaption></figure>
 
 Click Create App Integration and select OIDC - OpenID Connect as the Sign-In method. And then select Web Application as the application type.
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 1.39.15 PM.png" alt="A GitBook screenshot showing the Okta integration setup" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 1.39.15 PM.png" alt="An Okta screenshot showing the integration setup" ><figcaption></figcaption></figure>
 
 Name it appropriately and don't edit any other setting on that page. For assignments, choose the appropriate checkbox. Click Save.
 
 On the next screen, copy Client ID and Client Secret. Copy the Okta Domain right below your email address by clicking the dropdown in the top right.&#x20;
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 4.52.14 PM.png" alt="A GitBook screenshot showing where to copy client credentials" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2023-10-30 at 4.52.14 PM.png" alt="An Okta screenshot showing where to copy client credentials" ><figcaption></figcaption></figure>
 
 We will need these values to configure the Okta Integration.
 
@@ -52,7 +52,7 @@ We will need these values to configure the Okta Integration.
 
 Navigate to the Integrations tab in the site you want to publish and locate the Okta integration or navigate directly to this [https://app.gitbook.com/integrations/VA-Okta](https://app.gitbook.com/o/d8f63b60-89ae-11e7-8574-5927d48c4877/s/zq8ynchcecIscc4uulgN/).
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.21.30 PM.png" alt="A GitBook screenshot showing the Okta integration page" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-12-13 at 3.21.30 PM.png" alt="A GitBook screenshot showing the site settings page" ><figcaption></figcaption></figure>
 
 Install the integration on your site.
 
@@ -66,7 +66,7 @@ Click Save.
 
 Copy the URL displayed in the modal and enter it as a Sign-In redirect URI in Okta (as shown in the below screenshot). Hit Save.
 
-<figure><img src="../../.gitbook/assets/Screen Shot 2024-01-14 at 7.55.08 PM.png" alt="A GitBook screenshot showing the sign-in redirect URI configuration" ><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/Screen Shot 2024-01-14 at 7.55.08 PM.png" alt="An Okta screenshot showing the sign-in redirect URI configuration" ><figcaption></figcaption></figure>
 
 Now, in GitBook, close the integrations modal and click on the Manage site button. Navigate to **Audience**, select **Authenticated access**, and choose Okta as the backend. Then, click **Update audience**. Go to the site’s screen and click **Publish**.\
 \

--- a/publishing-documentation/customization/README.md
+++ b/publishing-documentation/customization/README.md
@@ -11,7 +11,7 @@ You can customize the appearance of your published documentation, match the user
 
 You can apply customizations to your entire docs site as a site-wide theme, or to individual variants and site sections.
 
-<figure><img src="../../.gitbook/assets/21_04_25_customization_published_site.svg" alt=""><figcaption><p>GitBook's own documentation is an example of a customized docs site.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_04_25_customization_published_site.svg" alt="A GitBook screenshot showing a customized docs site"><figcaption><p>GitBook's own documentation is an example of a customized docs site.</p></figcaption></figure>
 
 ### Customizing sites with multiple sections
 
@@ -22,12 +22,12 @@ Select the whole site or a specific site section using the drop-down menu at the
 * **Site-wide settings** – These automatically apply to all linked spaces.
 * **Section specific settings** – If you’re using site sections, you’re can set section specific customization that will override the default site-wise setting.
 
-<figure><img src="../../.gitbook/assets/19_02_2025_site_customization.svg" alt=""><figcaption><p>The customization panel in GitBook.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/19_02_2025_site_customization.svg" alt="A GitBook screenshot showing the customization panel"><figcaption><p>The customization panel in GitBook.</p></figcaption></figure>
 
 {% hint style="warning" %}
 Changes you make to specific site sections will override the site-wide customization settings, even if you change the site-wide setting again later.&#x20;
 
-You can reset customization overrides back to the site-wide default by clicking the **Reset** button <picture><source srcset="../../.gitbook/assets/reset_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/reset_icon_light.svg" alt=""></picture> next to the space selector.
+You can reset customization overrides back to the site-wide default by clicking the **Reset** button <picture><source srcset="../../.gitbook/assets/reset_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/reset_icon_light.svg" alt="The Reset icon in GitBook"></picture> next to the space selector.
 {% endhint %}
 
 ### What counts as ‘Advanced customization’?

--- a/publishing-documentation/customization/icons-colors-and-themes.md
+++ b/publishing-documentation/customization/icons-colors-and-themes.md
@@ -6,7 +6,7 @@ description: Customize icons, colors, themes and more.
 
 ### Title, icon and logo
 
-<figure><img src="../../.gitbook/assets/21_04_25_customization_title.svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_04_25_customization_title.svg" alt="A GitBook screenshot showing title, icon and logo customization"><figcaption></figcaption></figure>
 
 **Title**
 
@@ -34,7 +34,7 @@ The icon setting lets you upload a small, 132×132 px image, which will appear _
 
 Themes let you customize the color scheme of your published content for both light and dark mode. There are four themes to choose from. The colors of your site will be directly impacted by the **primary color** and **tint** that you choose. These two selections affect various parts of the interface and can completely change the look and feel of your site.
 
-<figure><img src="../../.gitbook/assets/21_04_25_customization_themes (1).svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_04_25_customization_themes (1).svg" alt="A GitBook screenshot showing theme options"><figcaption></figcaption></figure>
 
 #### Clean
 
@@ -58,7 +58,7 @@ A trendsetting theme featuring a gradient background and splashes of color. The 
 
 ### Colors
 
-<figure><img src="../../.gitbook/assets/21_04_25_customization_colors.svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_04_25_customization_colors.svg" alt="A GitBook screenshot showing color customization"><figcaption></figcaption></figure>
 
 #### Primary color
 
@@ -86,7 +86,7 @@ _Note: to change the theme within the GitBook app, go to your Settings menu at t
 
 ### Site styles
 
-<figure><img src="../../.gitbook/assets/21_04_25_customization_site_styles.svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_04_25_customization_site_styles.svg" alt="A GitBook screenshot showing site style settings"><figcaption></figcaption></figure>
 
 **Font family** <mark style="background-color:purple;">**(Premium & Ultimate)**</mark>
 
@@ -115,7 +115,7 @@ Choose between two link designs:
 
 ### Sidebar styles
 
-<figure><img src="../../.gitbook/assets/21_04_25_customization_sidebar (1).svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_04_25_customization_sidebar (1).svg" alt="A GitBook screenshot showing sidebar style options"><figcaption></figcaption></figure>
 
 **Background style**
 

--- a/publishing-documentation/customization/layout-and-structure.md
+++ b/publishing-documentation/customization/layout-and-structure.md
@@ -6,7 +6,7 @@ description: Customize the layout and structure of your published documentation.
 
 ### Header
 
-<figure><img src="../../.gitbook/assets/21_04_25_customization_header.svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_04_25_customization_header.svg" alt="A GitBook screenshot showing header customization settings"><figcaption></figcaption></figure>
 
 **Search bar**
 
@@ -30,7 +30,7 @@ Control the display of the “previous” and “next” buttons that appear at 
 
 ### Footer (Premium & Ultimate)
 
-<figure><img src="../../.gitbook/assets/21_04_25_customization_footer (1).svg" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/21_04_25_customization_footer (1).svg" alt="A GitBook screenshot showing footer customization settings"><figcaption></figcaption></figure>
 
 **Logo**
 

--- a/publishing-documentation/insights.md
+++ b/publishing-documentation/insights.md
@@ -13,7 +13,7 @@ You can see a top-level overview of your insights on the **Overview** tab of you
 
 Click the **Insights** tab in the site header to find more detailed insights for your site.&#x20;
 
-<figure><img src="../.gitbook/assets/03_02_25_advanced_site_insights.svg" alt=""><figcaption><p>The site insights dashboard.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/03_02_25_advanced_site_insights.svg" alt="A GitBook screenshot showing the site insights dashboard" ><figcaption><p>The site insights dashboard.</p></figcaption></figure>
 
 ### Filters & groups
 

--- a/publishing-documentation/publish-a-docs-site/README.md
+++ b/publishing-documentation/publish-a-docs-site/README.md
@@ -9,7 +9,7 @@ Once you’ve finished writing, editing, or importing your content, you can publ
 
 The content on your site comes from [spaces](../../creating-content/content-structure/space.md) in your organization. When you create a new docs site, you can create a new space, or link an existing one.
 
-<figure><img src="../../.gitbook/assets/10_01_25_docs_dashboard.svg" alt=""><figcaption><p>GitBook's docs sites homepage.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/10_01_25_docs_dashboard.svg" alt="A GitBook screenshot showing the docs sites homepage" ><figcaption><p>GitBook's docs sites homepage.</p></figcaption></figure>
 
 ### Create a docs site
 

--- a/publishing-documentation/site-redirects.md
+++ b/publishing-documentation/site-redirects.md
@@ -7,7 +7,7 @@ icon: diamond-turn-right
 
 {% include "../.gitbook/includes/premium-and-ultimate-hint.md" %}
 
-<figure><img src="../.gitbook/assets/10_01_25_redirects.svg" alt="A GitBook screenshot showing site redirect settings" ><figcaption><p>Site redirects are useful when migrating documentation or restructuring content to avoid broken links, which can impact SEO.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_redirects.svg" alt="A GitBook screenshot showing site redirects" ><figcaption><p>Site redirects are useful when migrating documentation or restructuring content to avoid broken links, which can impact SEO.</p></figcaption></figure>
 
 Redirects are commonly used when you are migrating your documentation from one provider to another — like when you just moved docs to GitBook. Broken links can impact SEO so we recommend setting up redirects where needed.
 

--- a/publishing-documentation/site-redirects.md
+++ b/publishing-documentation/site-redirects.md
@@ -7,7 +7,7 @@ icon: diamond-turn-right
 
 {% include "../.gitbook/includes/premium-and-ultimate-hint.md" %}
 
-<figure><img src="../.gitbook/assets/10_01_25_redirects.svg" alt=""><figcaption><p>Site redirects are useful when migrating documentation or restructuring content to avoid broken links, which can impact SEO.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_redirects.svg" alt="A GitBook screenshot showing site redirect settings" ><figcaption><p>Site redirects are useful when migrating documentation or restructuring content to avoid broken links, which can impact SEO.</p></figcaption></figure>
 
 Redirects are commonly used when you are migrating your documentation from one provider to another — like when you just moved docs to GitBook. Broken links can impact SEO so we recommend setting up redirects where needed.
 
@@ -25,7 +25,7 @@ If you want to add another redirect to the same page, you can toggle the **Add a
 
 ### Editing redirects
 
-To edit a redirect, press the **Edit** <picture><source srcset="../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/edit_icon_light.svg" alt=""></picture> icon next to it in the list. Update the redirect and hit **Save**.
+To edit a redirect, press the **Edit** <picture><source srcset="../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/edit_icon_light.svg" alt="The Edit icon in GitBook"></picture> icon next to it in the list. Update the redirect and hit **Save**.
 
 To delete a redirect, press the **Delete redirect** button and confirm.
 

--- a/publishing-documentation/site-settings.md
+++ b/publishing-documentation/site-settings.md
@@ -7,7 +7,7 @@ icon: gear
 
 {% include "../.gitbook/includes/customization-premium-and-ultimate-hint.md" %}
 
-<figure><img src="../.gitbook/assets/10_01_25_site_settings.svg" alt=""><figcaption><p>Update the settings for your published documentation.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_site_settings.svg" alt="A GitBook screenshot showing site settings" ><figcaption><p>Update the settings for your published documentation.</p></figcaption></figure>
 
 ### General
 

--- a/publishing-documentation/site-structure/README.md
+++ b/publishing-documentation/site-structure/README.md
@@ -19,7 +19,7 @@ From your docs site’s dashboard, open the **Settings** tab in the site header,
 
 Your site starts out with a single section with your site's name and a single variant with the space you linked during your site's set-up.
 
-<figure><img src="../../.gitbook/assets/14_03_25_site_structure.png" alt=""><figcaption><p>The structure of a published docs site.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/14_03_25_site_structure.png" alt="A GitBook screenshot showing a docs site's structure" ><figcaption><p>The structure of a published docs site.</p></figcaption></figure>
 
 ### Linking a space to your docs site
 
@@ -31,19 +31,19 @@ When you add a space — as a variant or a section — a name and slug will be g
 
 ### Changing sections or variants
 
-<div data-full-width="false"><figure><img src="../../.gitbook/assets/04_02_25_edit_variant.svg" alt=""><figcaption><p>Update a site section or variant.</p></figcaption></figure></div>
+<div data-full-width="false"><figure><img src="../../.gitbook/assets/04_02_25_edit_variant.svg" alt="A GitBook screenshot showing how to edit a variant" ><figcaption><p>Update a site section or variant.</p></figcaption></figure></div>
 
-You can change the name and slug of each of sections and variants by clicking the **Edit** <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt=""></picture> button in the table row of the item you’d like to edit. This will open a modal. Edit the field(s) you’d like to change, then click the **Save** button to save.
+You can change the name and slug of each of sections and variants by clicking the **Edit** <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt="The Edit icon in GitBook"></picture> button in the table row of the item you’d like to edit. This will open a modal. Edit the field(s) you’d like to change, then click the **Save** button to save.
 
 {% hint style="info" %}
 Changing a linked space's slug will change the space's canonical URL. GitBook will create an automatic redirect from the old URL to the new one. You can also [manually create redirects](../site-redirects.md).
 {% endhint %}
 
-To replace a section or variant, first delete it by clicking its **Edit** <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt=""></picture> button, then click the **Delete** button in the lower left of the modal. Once the item is deleted, click the **Add section** or **Add variant** button to add it again.
+To replace a section or variant, first delete it by clicking its **Edit** <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt="The Edit icon in GitBook"></picture> button, then click the **Delete** button in the lower left of the modal. Once the item is deleted, click the **Add section** or **Add variant** button to add it again.
 
 ### Reordering sections or variants
 
-Your site displays sections and variants in the order that they appear in your **Site structure** table. They can be reordered by grabbing the **Drag handle** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> and moving it up or down. The changed order will be reflected on your site immediately.
+Your site displays sections and variants in the order that they appear in your **Site structure** table. They can be reordered by grabbing the **Drag handle** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> and moving it up or down. The changed order will be reflected on your site immediately.
 
 You can also use the keyboard to select and move content. Select a section or variant with the space bar, then use the arrow keys to move it up or down. Hit the space bar again to confirm the new position.
 
@@ -53,7 +53,7 @@ If you have multiple sections in your site, one section will be marked as **Defa
 
 If you have multiple variants within a section, one variant will be marked as the default. Like sections, the default variant is shown when visitors arrive on your site, or when they visit a section. Other variants each have a slug that’s appended to the section’s URL.
 
-To set a space as default, click on the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> in the space’s table row and then click **Set as default**.
+To set a space as default, click on the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> in the space’s table row and then click **Set as default**.
 
 {% hint style="info" %}
 Setting a space as default removes its slug field, as it will be served from the section root instead. GitBooks redirects the space’s slug to the appropriate path, to ensure visitors keep seeing your content.
@@ -63,7 +63,7 @@ Setting a space as default removes its slug field, as it will be served from the
 
 To remove the content of a space from a site, open the **Settings** tab from your docs site dashboard, then click **Structure** to find the content you want to remove.&#x20;
 
-Open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> for the space you want to remove and choose **Remove**.
+Open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> for the space you want to remove and choose **Remove**.
 
 {% hint style="success" %}
 Removing a space from your site will remove it from the published site, but **will not delete the space or the content within it**.

--- a/publishing-documentation/site-structure/site-sections.md
+++ b/publishing-documentation/site-structure/site-sections.md
@@ -8,7 +8,7 @@ description: >-
 
 {% include "../../.gitbook/includes/ultimate-hint.md" %}
 
-<figure><img src="../../.gitbook/assets/14_03_25_site_sections_published.jpg" alt=""><figcaption><p>Example of a GitBook site with site sections</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/14_03_25_site_sections_published.jpg" alt="A GitBook screenshot showing site sections on a docs site" ><figcaption><p>Example of a GitBook site with site sections</p></figcaption></figure>
 
 With site sections, you can centralize all your documentation and create a seamless experience for your users.
 
@@ -30,7 +30,7 @@ From your docs site’s dashboard, open the **Settings** tab in the site header,
 
 To add a site section, click the **New section** button underneath the table and choose a space to link as a section. The new section is then added to the table and will be available to visitors as a tab at the top of your site.
 
-<figure><img src="../../.gitbook/assets/14_03_25_site_structure.png" alt=""><figcaption><p>Add structure to your docs with site sections.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/14_03_25_site_structure.png" alt="A GitBook screenshot showing site section structure" ><figcaption><p>Add structure to your docs with site sections.</p></figcaption></figure>
 
 ### Create a site section group
 
@@ -40,7 +40,7 @@ To create a group, click the arrow next to the **New section** button and choose
 
 ### Editing a section
 
-You can change the name, icon and slug of each of your sections by tapping the <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt=""></picture> **Edit** button in the table row of the section you’d like to edit. This will open a modal. Edit the field(s) you’d like to change, then click the **Save** button. You can also delete the variant by clicking the **Delete variant** button in the lower left.
+You can change the name, icon and slug of each of your sections by tapping the <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt="The Edit icon in GitBook"></picture> **Edit** button in the table row of the section you’d like to edit. This will open a modal. Edit the field(s) you’d like to change, then click the **Save** button. You can also delete the variant by clicking the **Delete variant** button in the lower left.
 
 {% hint style="info" %}
 Changing a section’s slug will change its canonical URL. GitBook will create an automatic redirect from the old URL to the new one. You can also [manually create redirects](../site-redirects.md).
@@ -50,7 +50,7 @@ Site sections within a group can also optionally display a description, which wi
 
 ### Reordering sections
 
-Your site displays sections in the order that they appear in your Site structure table. Sections can be reordered by grabbing the **Drag handle** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> and moving it up or down. All the spaces within that section will be moved with it. The changed order will be reflected on your site immediately.
+Your site displays sections in the order that they appear in your Site structure table. Sections can be reordered by grabbing the **Drag handle** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> and moving it up or down. All the spaces within that section will be moved with it. The changed order will be reflected on your site immediately.
 
 You can also use the keyboard to select and move content: select a section with the space bar, then use the arrow keys to move it up or down. Hit the space bar again to confirm the new position.
 
@@ -58,15 +58,15 @@ You can also use the keyboard to select and move content: select a section with 
 
 If you have multiple sections in your site, one section will be marked as the default. This section is shown when visitors arrive on your site, and is served from your site’s root URL. Other sections each have a slug that is appended to the root URL.
 
-To set a section as default, click on the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> in the section's table row and then click **Set as default**.
+To set a section as default, click on the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> in the section's table row and then click **Set as default**.
 
 ### Remove a section
 
-To remove a section from a site, click the **Settings** <picture><source srcset="../../.gitbook/assets/settings_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/settings_icon_light.svg" alt=""></picture> button from your docs site dashboard, then click **Structure** to find the content you want to remove. Click the **Edit** <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt=""></picture> button next to the section you want to remove, then click the **Delete** button in the lower left of the modal. This will remove the section, along with all the variants within it, from the published site. It will not delete the spaces itself, or the content within them.
+To remove a section from a site, click the **Settings** <picture><source srcset="../../.gitbook/assets/settings_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/settings_icon_light.svg" alt="The Settings icon in GitBook"></picture> button from your docs site dashboard, then click **Structure** to find the content you want to remove. Click the **Edit** <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt="The Edit icon in GitBook"></picture> button next to the section you want to remove, then click the **Delete** button in the lower left of the modal. This will remove the section, along with all the variants within it, from the published site. It will not delete the spaces itself, or the content within them.
 
 To remove a section from a site, open the **Settings** tab from your docs site dashboard, then click **Structure** to find the content you want to remove.&#x20;
 
-Open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> for the space you want to remove and choose **Remove**.
+Open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> for the space you want to remove and choose **Remove**.
 
 {% hint style="success" %}
 Removing a section from your site will remove it — and all variants within it — from the published site, but **will not delete any of the spaces or the content within them**.

--- a/publishing-documentation/site-structure/variants.md
+++ b/publishing-documentation/site-structure/variants.md
@@ -8,7 +8,7 @@ description: >-
 
 You can publish multiple versions of the same documentation as part of a single docs site. These variants will be available to the end users via the space switcher in the top-left corner of the published site.
 
-<figure><img src="../../.gitbook/assets/14_03_25_site_structure.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/14_03_25_site_structure.png" alt="A GitBook screenshot showing a docs site's structure"><figcaption></figcaption></figure>
 
 ### Add multiple languages or versions
 
@@ -26,17 +26,17 @@ To add a variant, click the **Add variant** button in the section you'd like to 
 
 ### Changing a variant
 
-You can change the name and slug of each of your variants by clicking the <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt=""></picture> **Edit** button in the table row of the variant you’d like to edit. This will open a modal. Edit the field(s) you'd like to change, then click the **Save** button to save. You can also delete the variant by clicking the **Delete variant** button in the lower left.
+You can change the name and slug of each of your variants by clicking the <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt="The Edit icon in GitBook"></picture> **Edit** button in the table row of the variant you’d like to edit. This will open a modal. Edit the field(s) you'd like to change, then click the **Save** button to save. You can also delete the variant by clicking the **Delete variant** button in the lower left.
 
 {% hint style="info" %}
 Changing a linked space's slug will change the space's canonical URL. GitBook will create an automatic redirect from the old URL to the new one. You can also [manually create redirects](../site-redirects.md).
 {% endhint %}
 
-To replace a variant’s linked space with a different space, first delete it by clicking its **Edit** <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt=""></picture> button, then click the **Delete** button in the lower left of the modal. Once the variant is deleted, click the **Add variant** button to add the new space.
+To replace a variant’s linked space with a different space, first delete it by clicking its **Edit** <picture><source srcset="../../.gitbook/assets/edit_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/edit_icon_light.svg" alt="The Edit icon in GitBook"></picture> button, then click the **Delete** button in the lower left of the modal. Once the variant is deleted, click the **Add variant** button to add the new space.
 
 ### Reordering variants
 
-Your site displays variants in the order that they appear in your **Site structure** table. Variants can be reordered by grabbing the **Drag handle** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt=""></picture> and moving it up or down. The changed order will be reflected on your site immediately.
+Your site displays variants in the order that they appear in your **Site structure** table. Variants can be reordered by grabbing the **Drag handle** <picture><source srcset="../../.gitbook/assets/options_menu_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/options_menu_icon_light.svg" alt="The Options menu icon in GitBook"></picture> and moving it up or down. The changed order will be reflected on your site immediately.
 
 You can also use the keyboard to select and move content: select a section or variant with the space bar, then use the arrow keys to move it up or down. Hit the space bar again to confirm the new position.
 
@@ -44,7 +44,7 @@ You can also use the keyboard to select and move content: select a section or va
 
 If you have multiple variants within a section, one variant will be marked as the default. This variant is shown when visitors arrive on your site (or when they visit a section). Other variants each have a slug that is appended to the site's URL.
 
-To set a variant as default, click on the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> in the variant’s table row and then click **Set as default**.
+To set a variant as default, click on the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> in the variant’s table row and then click **Set as default**.
 
 {% hint style="info" %}
 Setting a variant as default removes its slug field, as it will be served from the section root instead. GitBook will redirect the variant's slug to the appropriate path, to ensure visitors keep seeing your content.
@@ -54,7 +54,7 @@ Setting a variant as default removes its slug field, as it will be served from t
 
 To remove a variant from a site, open the **Settings** tab from your docs site dashboard, then click **Structure** to find the content you want to remove.&#x20;
 
-Open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt=""></picture> for the variant you want to remove and choose **Remove**.
+Open the **Actions menu** <picture><source srcset="../../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> for the variant you want to remove and choose **Remove**.
 
 {% hint style="success" %}
 Removing a variant from your site will remove it from the published site, but **will not delete the space or the content within it**.

--- a/resources/gitbook-ui.md
+++ b/resources/gitbook-ui.md
@@ -9,7 +9,7 @@ GitBook is split into different sections to make it easier to organize and manag
 
 ### Sidebar
 
-<figure><img src="../.gitbook/assets/10_01_25_ui_sidebar.svg" alt=""><figcaption><p>The GitBook sidebar holds all of your documentation, as well as notifications, the search bar, snippets and more.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_ui_sidebar.svg" alt="A GitBook screenshot showing the sidebar" ><figcaption><p>The GitBook sidebar holds all of your documentation, as well as notifications, the search bar, snippets and more.</p></figcaption></figure>
 
 The sidebar allows you to see and overview of your GitBook organization at a glance. The sidebar contains:
 
@@ -36,7 +36,7 @@ The sidebar allows you to see and overview of your GitBook organization at a gla
 
 ### Table of contents
 
-<figure><img src="../.gitbook/assets/10_01_25_ui_table_of_contents.svg" alt=""><figcaption><p>The table of contents lists all the pages and links in your selected space.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_ui_table_of_contents.svg" alt="A GitBook screenshot showing the table of contents" ><figcaption><p>The table of contents lists all the pages and links in your selected space.</p></figcaption></figure>
 
 By default, the table of contents shows a list of [pages, links, and groups](../creating-content/content-structure/page.md#organizing-your-content) that make up a space. You’ll find it to the right of the sidebar. It’s specific to the space you’re currently viewing.
 
@@ -48,7 +48,7 @@ From the **Pages** tab in the table of contents you can:
 * Create [page groups](gitbook-ui.md#groups)
 * Add [external links](gitbook-ui.md#external-links)
 * [import external docs](../getting-started/import.md) like websites or Markdown files
-* Access [the Actions menu](gitbook-ui.md#the-actions-menu) <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> for individual pages.
+* Access [the Actions menu](gitbook-ui.md#the-actions-menu) <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> for individual pages.
 
 In the **Reusable content** tab, you can:
 
@@ -63,11 +63,11 @@ In the **Files** tab, you can:
 * Drag and drop more files into your space
 * Manage individual files
 
-If you want to give more focus to the content of your page, you can temporarily hide the table of contents by hovering your cursor next to it and clicking the **Hide** button <picture><source srcset="../.gitbook/assets/panel_close_left_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/panel_close_left_icon_light.svg" alt=""></picture> that appears. To make it appear again, hover your cursor near the edge of the page and click the **Show** button <picture><source srcset="../.gitbook/assets/open_panel_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/open_panel_icon_light.svg" alt=""></picture>.
+If you want to give more focus to the content of your page, you can temporarily hide the table of contents by hovering your cursor next to it and clicking the **Hide** button <picture><source srcset="../.gitbook/assets/panel_close_left_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/panel_close_left_icon_light.svg" alt="The Hide button icon in GitBook"></picture> that appears. To make it appear again, hover your cursor near the edge of the page and click the **Show** button <picture><source srcset="../.gitbook/assets/open_panel_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/open_panel_icon_light.svg" alt="The Show button icon in GitBook"></picture>.
 
 ### Space header
 
-<figure><img src="../.gitbook/assets/03_02_25_space_header.svg" alt=""><figcaption><p>The space header sits at the top of the editor, and offers options that apply to the whole space.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/03_02_25_space_header.svg" alt="A GitBook screenshot showing the space header" ><figcaption><p>The space header sits at the top of the editor, and offers options that apply to the whole space.</p></figcaption></figure>
 
 The space header contains information about the space you’re currently viewing. It lets you do things like publish and share your space, view the comments and history for the space, configure [GitHub or GitLab sync](../getting-started/git-sync/), and more.
 
@@ -85,7 +85,7 @@ The space header includes:
   The name of the space that will appear in the sidebar, and your documentation if and when you choose to publish it.
 * **The space’s breadcrumbs**\
   A full, linear list of the collections or docs sites the space lives in.
-* **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt=""></picture>\
+* **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt="The Actions menu icon in GitBook"></picture>\
   Offers a list of actions for your space. Similar to [page actions](gitbook-ui.md#the-actions-menu), the available actions for a space will differ depending on the mode you’re currently in.
 * **Editor view**\
   This view is where you can make edits to your content using GitBook’s block-based editor.
@@ -120,7 +120,7 @@ The site header includes:
   The name of the space that will appear in the sidebar, and your documentation if and when you choose to publish it.
 * **The site’s breadcrumbs**\
   A link back to the main Docs sites screen.
-* **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt=""></picture>\
+* **Actions menu** <picture><source srcset="../.gitbook/assets/actions-horizontal - dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions-horizontal.svg" alt="The Actions menu icon in GitBook"></picture>\
   Offers a list of actions for your site. You can visit your site or copy its URL quickly from this menu
 * **Overview**\
   The site overview shows you essential information about your site including it’s URL, publish status, audience and content, as well as top-level insights.
@@ -152,14 +152,14 @@ At the top of each page you can set a **title**, add an optional **emoji**, and 
 Your page description can be a maximum of 200 characters long, and will act as the preview text for your page in search engines.
 
 {% hint style="info" %}
-You can change the URL slug for a page by choosing **Page Actions** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> > **Rename**. Find out more about [Page Actions](gitbook-ui.md#page-options) below.
+You can change the URL slug for a page by choosing **Page Actions** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> > **Rename**. Find out more about [Page Actions](gitbook-ui.md#page-options) below.
 {% endhint %}
 
 ### Page actions menu
 
-The page’s **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> allows you to do things like duplicate, rename or delete your page.
+The page’s **Actions menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> allows you to do things like duplicate, rename or delete your page.
 
-You can open the **Actions menu** using the <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> icon that appears when hovering over your page in the sidebar, or from the icon next to the page title.
+You can open the **Actions menu** using the <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> icon that appears when hovering over your page in the sidebar, or from the icon next to the page title.
 
 {% hint style="info" %}
 The type of actions available will depend on whether you’re in [live editing](../collaboration/live-edits.md) mode or a [change request](../collaboration/change-requests.md).
@@ -167,11 +167,11 @@ The type of actions available will depend on whether you’re in [live editing](
 
 ### Page options
 
-<figure><img src="../.gitbook/assets/10_01_25_ui_page_options.svg" alt=""><figcaption><p>The <strong>Page options</strong> side panel offers customization options for your documentation and navigation.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_ui_page_options.svg" alt="A GitBook screenshot showing the Page options side panel" ><figcaption><p>The <strong>Page options</strong> side panel offers customization options for your documentation and navigation.</p></figcaption></figure>
 
 With page options, you cam customize your documentation layout and navigation. You can only access page options if you’re in an editing mode.
 
-You can open the **Page options** side panel by opening the page’s **Action menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt=""></picture> and choosing **Options**, or by hovering over the main title of the page and clicking **Page options** when it appears.
+You can open the **Page options** side panel by opening the page’s **Action menu** <picture><source srcset="../.gitbook/assets/actions_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/actions_icon_light.svg" alt="The Actions menu icon in GitBook"></picture> and choosing **Options**, or by hovering over the main title of the page and clicking **Page options** when it appears.
 
 {% hint style="info" %}
 Certain changes, such as disabling the table of content, only apply to published documentation and may not be visible in the editor.
@@ -179,7 +179,7 @@ Certain changes, such as disabling the table of content, only apply to published
 
 ### Page outline
 
-<figure><img src="../.gitbook/assets/10_01_25_ui_page_outline.svg" alt=""><figcaption><p>The page outline shows H1 and H2 headings, allowing you to quickly jump to a specific section on an individual page.</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/10_01_25_ui_page_outline.svg" alt="A GitBook screenshot showing the page outline" ><figcaption><p>The page outline shows H1 and H2 headings, allowing you to quickly jump to a specific section on an individual page.</p></figcaption></figure>
 
 The **page outline** sits on the right-hand side of the editor, and makes it easy to jump directly to the section of the page you’re looking for.
 

--- a/snippets/snippets-beta.md
+++ b/snippets/snippets-beta.md
@@ -20,7 +20,7 @@ In GitBook, you can capture unstructured information using [integrations](broken
 
 GitBook will index all of your snippets alongside the rest of your content and can reference them when you or your team [searches for information](../creating-content/searching-your-content/). You can also merge snippets into existing docs or content to keep everything up to date.
 
-<figure><img src="broken-reference" alt=""><figcaption><p>The <strong>Snippets</strong> page holds all of your snippets in one place and makes it easy to connect integrations so you can add more.</p></figcaption></figure>
+<figure><img src="broken-reference" alt="A GitBook screenshot showing the Snippets page"><figcaption><p>The <strong>Snippets</strong> page holds all of your snippets in one place and makes it easy to connect integrations so you can add more.</p></figcaption></figure>
 
 ### Product Demo
 
@@ -46,7 +46,7 @@ You can create a snippet manually from the **Snippets** page, by clicking the **
 
 You can edit a snippet you’ve captured by clicking to open it from the **Snippets** page. This will open an editor view, where you can edit any information that might be wrong, or add additional context for things that might be missing.
 
-<figure><img src="broken-reference" alt=""><figcaption><p>You can edit a snippet directly in the editor by opening it.</p></figcaption></figure>
+<figure><img src="broken-reference" alt="A GitBook screenshot showing a snippet being edited in the editor"><figcaption><p>You can edit a snippet directly in the editor by opening it.</p></figcaption></figure>
 
 ### Share a snippet
 


### PR DESCRIPTION
## Summary
- Add alt text for screenshots and inline icons across docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68540b946ffc8326b4701e5271dd6e11