### PR TITLE
Rename 'OpenAPI Reference' to 'API Reference'

### DIFF
--- a/api-references/openapi/insert-api-reference-in-your-docs.md
+++ b/api-references/openapi/insert-api-reference-in-your-docs.md
@@ -24,7 +24,7 @@ After you’ve [added your OpenAPI spec](add-an-openapi-specification.md), you c
 
 In the space you’d like to generate endpoint pages, click the **Add new...** button from the bottom of your space’s [table of contents](../../resources/gitbook-ui.md#table-of-contents).
 
-From here, click **OpenAPI Reference**.
+From here, click **API Reference**.
 {% endstep %}
 
 {% step %}


### PR DESCRIPTION
The docs mention OpenAPI Reference, but it's actually API Reference.

<img width="272" height="265" alt="image" src="https://github.com/user-attachments/assets/d67bf505-933e-4c64-bc64-eead702a7f5e" />
