### PR TITLE
Update documentation on footnote formatting

### DIFF
--- a/creating-content/formatting/inline.md
+++ b/creating-content/formatting/inline.md
@@ -18,10 +18,10 @@ To create an annotation, select the text you would like to annotate and click th
 
 #### Markdown representation
 
-You can write content as [Markdown footnotes](https://www.markdownguide.org/extended-syntax/#footnotes) to add them as annotations in GitBook.
+You can write content as [Markdown footnotes](https://www.markdownguide.org/extended-syntax/#footnotes) to add them as annotations in GitBook. Footnote indicators should appear immediately after the word you wish to annotate; they should not appear after punctuation marks or other symbols.
 
 ```markdown
-Here's a simple footnote,[^1] and here's a longer one.[^bignote]
+Here's a simple footnote[^1], and here's a longer one[^bignote].
 
 [^1]: This is the first footnote.
 


### PR DESCRIPTION
After a helpful conversation with Rodrigo from @GitBookIO, update the "Inline content" documentation to clarify where footnote indicators should appear in order to render correctly. Annotations will not render if footnote indicators follow punctuation marks or other symbols; they must immediately follow the word a user wishes to annotate.