### PR TITLE
Correct markdown representation for hints with titles

### DIFF
--- a/creating-content/blocks/hint.md
+++ b/creating-content/blocks/hint.md
@@ -65,12 +65,11 @@ To add a heading to your hint, you need to create a heading block as the the fir
 **Danger hints** are good for highlighting destructive actions or raising attention to critical information.
 {% endhint %}
 
-{% hint style="info" %}
-
 {% hint style="info" icon="books" %}
 This hint block has a custom icon.
 {% endhint %}
 
+{% hint style="info" %}
 ## This is a H2 heading
 
 This is a line


### PR DESCRIPTION
Corrected the markdown representation syntax for hints with headers. The opening hint syntax seemed to have got detached further up the codeblock. This puts it back in the correct place.