### PR TITLE
All content page + Home naming fix

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -69,6 +69,7 @@
   * [Groups](creating-content/content-structure/collection.md)
   * [Pages](creating-content/content-structure/page/README.md)
     * [Tags](creating-content/content-structure/page/tags.md)
+* [All content](creating-content/all-content.md)
 * [Blocks](creating-content/blocks/README.md)
   * [Paragraphs](creating-content/blocks/paragraph.md)
   * [Headings](creating-content/blocks/heading.md)

--- a/account-management/account-settings.md
+++ b/account-management/account-settings.md
@@ -11,7 +11,7 @@ You can manage your login details, third-party login options, GitBook subdomain,
 
 ### How to access your personal account settings
 
-Go back to **All Sites** and click **Settings**. Account and organization settings share one screen, grouped into **Account** and **Organization** in the left-hand sidebar. Your personal settings live under **Account**. Click **Back to app** to return to your content.
+Go back to your organization **Home** and click **Settings**, under **Admin** in the sidebar. Account and organization settings share one screen, grouped into **Account** and **Organization** in the left-hand sidebar. Your personal settings live under **Account**. Click **Back to app** to return to your content.
 
 <details>
 

--- a/collaboration/merge-rules.md
+++ b/collaboration/merge-rules.md
@@ -23,7 +23,7 @@ You can configure merge rules at different levels to match your team’s workflo
 
 Organizations can set default merge rules that all sections inherit. This provides consistency across multiple sections while still allowing individual sections to customize their rules as needed.
 
-To configure merge rules for your organization, go back to **All Sites** and click **Settings** <picture><source srcset="../.gitbook/assets/25_01_10_settings_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/25_01_10_settings_icon_light.svg" alt=""></picture>. In the settings screen, click **Merge rules** under the **Organization** group. Here you can specify merge rules for your entire organization.
+To configure merge rules for your organization, go back to your organization **Home** and click **Settings** <picture><source srcset="../.gitbook/assets/25_01_10_settings_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/25_01_10_settings_icon_light.svg" alt=""></picture>, under **Admin** in the sidebar. In the settings screen, click **Merge rules** under the **Organization** group. Here you can specify merge rules for your entire organization.
 
 Choose between unrestricted merging, or select from the list of presets to apply to change requests across your entire organization.
 

--- a/creating-content/all-content.md
+++ b/creating-content/all-content.md
@@ -1,0 +1,32 @@
+---
+description: >-
+  Browse, search, and manage content across all of your sites — and content
+  that isn’t part of a site yet — from one screen
+icon: files
+---
+
+# All content
+
+In GitBook’s site-centric model, your content lives in [sections](../docs-site/site-structure/site-sections.md) that belong to a docs site. The **All content** screen gives you one place to see everything in your organization: content from every site, and content that isn’t part of a site yet.
+
+### Open All content
+
+From your organization **Home**, click **Content** in the sidebar.
+
+### Browse, filter, and search
+
+Each row shows the content’s name and when it was last updated. Click a row to open it.
+
+To narrow the list, click the **All sites** filter and choose a site. To find something by name, use the **Search content** field.
+
+### Create content
+
+Click **Create content** to start new content from this screen.
+
+In the site-centric model, content belongs with a parent site. Create new content inside a site whenever you can — it keeps your structure, permissions, and publishing in one place. See [Site structure](../docs-site/site-structure/README.md) to learn how sections fit into a site.
+
+### Content that isn’t part of a site
+
+If your organization used GitBook before the site-centric model, some of your content may not belong to a site. It still appears in **All content**, and you can keep editing and collaborating on it here.
+
+To publish that content, add it to a site as a section. Learn more in [Site structure](../docs-site/site-structure/README.md).

--- a/gitbook-agent/translations.md
+++ b/gitbook-agent/translations.md
@@ -30,7 +30,7 @@ Page slugs in auto-translated sections may change unless the page has a fixed sl
 
 ## Set up an auto translation
 
-To translate a section to a new language, go back to **All Sites** and click **Settings**. In the settings screen, click **Translations** under the **Organization** group, then click **Create translation**.
+To translate a section to a new language, go back to your organization **Home** and click **Settings**, under **Admin** in the sidebar. In the settings screen, click **Translations** under the **Organization** group, then click **Create translation**.
 
 In the **Create translation** modal, choose a:
 

--- a/integrations/install-an-integration.md
+++ b/integrations/install-an-integration.md
@@ -19,7 +19,7 @@ If you install an integration in a single section, it will only work in that spe
 
 #### 1. Open the integrations screen
 
-Before enabling an integration in a section or site, you'll need to install it in your organization. Go back to **All Sites** and click **Settings**, then click **Integrations** under the **Organization** group. Browse integrations by category, or search for the one you need.
+Before enabling an integration in a section or site, you'll need to install it in your organization. Go back to your organization **Home** and click **Settings**, under **Admin** in the sidebar, then click **Integrations** under the **Organization** group. Browse integrations by category, or search for the one you need.
 
 Once an integration is installed in your organization, you can also work with it at the site level — click **Integrations**, under **Extend** in the site sidebar. Integrations already added to the site appear under **Installed integrations**.
 


### PR DESCRIPTION
Follow-up to #130.

- **New page**: creating-content/all-content.md — the org-wide Content screen: browse/filter/search across sites, Create content, and content that isn't part of a site yet (deliberately called just "content").
- **Naming fix**: the org landing is **Home** (per current build), not **All Sites**. Patched the four settings paths merged in #130 (merge-rules, account-settings, translations, install-an-integration) to "organization **Home** → **Settings** under **Admin**".

⚠️ Note for app-side CRs (not touched here): quickstart.md, resources/gitbook-ui/, docs-site/publish-a-docs-site/, and docs-site/sites-first.md still contain 11 "All Sites" references and need the same rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)