### PR TITLE
UI round 2: direct sidebar links + Home rename everywhere

### DIFF
--- a/account-management/organization-settings.md
+++ b/account-management/organization-settings.md
@@ -14,7 +14,7 @@ View and manage your GitBook organization’s settings. These include members, s
 
 ### Access the settings for an organization
 
-1. In the sidebar, click the organization switcher.
+1. At the top of the sidebar, open the organization menu.
 2. Click **Settings**.
 
 Settings open in a dedicated screen. Your personal **Account** settings include **General**, **Notifications**, **Organizations**, and **Developer tools**. Your **Organization** settings appear in the sidebar. Click **Back to app** to return to your work.
@@ -55,7 +55,7 @@ Add and remove [members](../collaboration/member-management/). You can also upda
 
 <summary>Merge rules</summary>
 
-Control how change requests are reviewed and merged across your organization. Organization rules apply to every space by default. Each space can inherit, replace, or disable those rules. Learn more about [merge rules](../collaboration/merge-rules.md).
+Control how change requests are reviewed and merged across your organization. Organization rules apply to every section by default. Each section can inherit, replace, or disable those rules. Learn more about [merge rules](../collaboration/merge-rules.md).
 
 </details>
 

--- a/creating-content/all-content.md
+++ b/creating-content/all-content.md
@@ -23,7 +23,7 @@ To narrow the list, click the **All sites** filter and choose a site. To find so
 
 Click **Create content** to start new content from this screen.
 
-Its best that content belongs to a parent site. Create new content inside a site whenever you can — it keeps your structure, permissions, and publishing in one place. See [Site structure](../docs-site/site-structure/) to learn how sections fit into a site.
+It’s best that content belongs to a parent site. Create new content inside a site whenever you can — it keeps your structure, permissions, and publishing in one place. See [Site structure](../docs-site/site-structure/) to learn how sections fit into a site.
 
 ### Content that isn’t part of a site
 

--- a/docs-site/publish-a-docs-site/README.md
+++ b/docs-site/publish-a-docs-site/README.md
@@ -9,13 +9,13 @@ When you finish writing, editing, or importing your content, publish it for your
 
 A docs site's content lives in its [sections](../site-structure/). The structure you edit is the structure visitors get. New sections start as drafts, so you control what appears on your published site.
 
-<figure><img src="../../.gitbook/assets/25_12_10_publishing_documentation_publish_docs@2x.png" alt="A GitBook screenshot showing the All Sites screen"><figcaption><p>The All Sites screen.</p></figcaption></figure>
+<figure><img src="../../.gitbook/assets/25_12_10_publishing_documentation_publish_docs@2x.png" alt="A GitBook screenshot showing the organization Home"><figcaption><p>Your organization Home.</p></figcaption></figure>
 
 ### Create a docs site
 
 To create a docs site:
 
-1. From the **All Sites** screen, click the **+** icon next to **Sites**.
+1. From your organization **Home**, click the **+** icon next to **Sites**.
 2. Enter a name that visitors will recognize.
 3. Click **Create**.
 4. Select a starting point: a documentation template, an import, an OpenAPI specification, a blank section, or Git Sync.
@@ -30,7 +30,7 @@ You can manage site permissions in **Settings** → **Members**. This lets you c
 
 To publish your site:
 
-1. From the **All Sites** screen, open your site.
+1. From your organization **Home**, open your site.
 2. Click **Publish** in the site header.
 
 Sites are public by default. Change your site's visibility in **Settings** → **Audience**. See [Site settings](../site-settings.md).
@@ -48,4 +48,4 @@ To delete a docs site:
 1. Open **Settings** → **General**.
 2. Select [**Delete site**](../site-settings.md#delete-site).
 
-Deleting a site permanently removes its settings and customizations. Your content remains in its space.
+Deleting a site permanently removes its settings and customizations. Your content remains in your organization — find it in [All content](../../creating-content/all-content.md).

--- a/docs-site/sites-first.md
+++ b/docs-site/sites-first.md
@@ -26,9 +26,9 @@ The site workspace closes that gap. Your organization contains sites, and every 
 
 ### What’s new
 
-#### All Sites is your new home
+#### Home shows all your sites
 
-When you open GitBook, you land on the **All Sites** screen: every docs site in your organization, in one place. It replaces the old Home screen as your starting point. To get back to it from anywhere, use the switcher at the top of the sidebar.
+When you open GitBook, you land on your organization **Home**: your docs sites, recent changes, and organization-wide tools, in one place. To get back to it from anywhere, use the switcher at the top of the sidebar.
 
 #### The sidebar shows your site, not your org
 
@@ -56,7 +56,7 @@ To see how drafts will look on your site, switch the site preview between **Live
 
 #### Organization settings, in context
 
-Organization settings no longer take over the whole screen. They open in context at the organization level, alongside the All Sites screen, so you can adjust organization-wide options without losing your place.
+Organization settings no longer take over the whole screen. They open in context at the organization level, alongside your organization Home, so you can adjust organization-wide options without losing your place.
 
 #### Site-inherited permissions
 

--- a/getting-started/quickstart.md
+++ b/getting-started/quickstart.md
@@ -19,7 +19,7 @@ At the end of this guide, you’ll have a live documentation site, ready to expa
 {% step %}
 #### Create your first site
 
-1. From the **All Sites** screen, click the **+** next to **Sites** in the sidebar.
+1. From your organization **Home**, click the **+** next to **Sites** in the sidebar.
 2. Give your site a name your visitors will recognize.
 3. Click **Create**.
 {% endstep %}
@@ -131,7 +131,7 @@ Your site looks great out of the box — and under **Customize**, you can set yo
 
 You can publish your site with a click at any time.
 
-1. Open your site from the **All Sites** screen.
+1. Open your site from your organization **Home**.
 2. Click **Publish** in the site header.
 
 Once your site is live, the **Overview** screen updates with a link to the live site.

--- a/gitbook-agent/translations.md
+++ b/gitbook-agent/translations.md
@@ -30,7 +30,7 @@ Page slugs in auto-translated sections may change unless the page has a fixed sl
 
 ## Set up an auto translation
 
-To translate a section to a new language, go back to your organization **Home** and click **Settings**, under **Admin** in the sidebar. In the settings screen, click **Translations** under the **Organization** group, then click **Create translation**.
+To translate a section to a new language, go back to your organization **Home** and click **Translations** in the sidebar, then click **Create translation**.
 
 In the **Create translation** modal, choose a:
 

--- a/integrations/install-an-integration.md
+++ b/integrations/install-an-integration.md
@@ -19,7 +19,7 @@ If you install an integration in a single section, it will only work in that spe
 
 #### 1. Open the integrations screen
 
-Before enabling an integration in a section or site, you'll need to install it in your organization. Go back to your organization **Home** and click **Settings**, under **Admin** in the sidebar, then click **Integrations** under the **Organization** group. Browse integrations by category, or search for the one you need.
+Before enabling an integration in a section or site, you'll need to install it in your organization. Go back to your organization **Home** and click **Integrations** in the sidebar. Browse integrations by category, or search for the one you need.
 
 Once an integration is installed in your organization, you can also work with it at the site level — click **Integrations**, under **Extend** in the site sidebar. Integrations already added to the site appear under **Installed integrations**.
 

--- a/resources/gitbook-ui/README.md
+++ b/resources/gitbook-ui/README.md
@@ -6,16 +6,16 @@ icon: sidebar
 
 # GitBook UI
 
-GitBook is organized around your docs sites. You start at the **All Sites** screen, open a site to work on its content, and edit pages inside sections. This page walks through each part of the interface.
+GitBook is organized around your docs sites. You start at your organization **Home**, open a site to work on its content, and edit pages inside sections. This page walks through each part of the interface.
 
-### All Sites
+### Home
 
-<div data-with-frame="true"><figure><img src="../../.gitbook/assets/25_12_10_gitbook_ui_1.png" alt=""><figcaption><p>The All Sites screen gives you access to sites, content, and organization controls.</p></figcaption></figure></div>
+<div data-with-frame="true"><figure><img src="../../.gitbook/assets/25_12_10_gitbook_ui_1.png" alt=""><figcaption><p>Your organization Home gives you access to sites, content, and organization controls.</p></figcaption></figure></div>
 
-When you open GitBook, you land on **All Sites**: every docs site in your organization, in one place. From here you can open a site, create a new one, or adjust organization-wide settings. All Sites contains:
+When you open GitBook, you land on your organization **Home**: every docs site in your organization, in one place. From here you can open a site, create a new one, or adjust organization-wide settings. Home contains:
 
 * **Switcher**\
-  Get back to **All Sites** from anywhere using the switcher at the top of the sidebar. If you're part of multiple organizations, see and switch between them here, or create a new organization.
+  Get back to **Home** from anywhere using the switcher at the top of the sidebar. If you're part of multiple organizations, see and switch between them here, or create a new organization.
 * **Notifications**\
   When you're tagged in a comment or conversation, or when there is important activity in a section you're working in, you get a [notification](../../collaboration/notifications.md) to show you what's new.
 * **Ask or search**\


### PR DESCRIPTION
Fixes from the 2026-07-23 UI meeting audit.

**Commit 1 — sweep-owned pages:** Translations and Integrations now route via their restored direct org-sidebar links instead of Home > Settings; "It's" typo on All content.

**Commit 2 — previously app-owned pages** (drop this commit if you'd rather do these via app CR): All Sites → organization **Home** in quickstart, publish-a-docs-site, gitbook-ui (section renamed Home), and sites-first (narrative reworked since "replaces the old Home screen" is now self-contradictory); organization-settings "organization switcher" → organization menu and "every space" → section; deleted-site note now points at All content.

**Deliberately not documented** (pending final UI labels): the Published/Visit button states, the orphan-space label, Claire's open question on filtering site spaces from the orphan-space content list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)