### PR TITLE
Rollout-status note on sites-first

### DIFF
--- a/docs-site/sites-first.md
+++ b/docs-site/sites-first.md
@@ -16,6 +16,10 @@ GitBook is now reorganized to be a site specific. Everything in the app is organ
 
 This page explains what changed, what it means for your existing content, and how to opt in.
 
+{% hint style="info" %}
+**Who has the new experience?** Organizations created in the past month already have it. Any existing organization can enable it today, and we’re gradually rolling it out to everyone. If your app doesn’t match these docs yet, that’s why.
+{% endhint %}
+
 <figure><img src="../.gitbook/assets/site-centric @2x.png" alt=""><figcaption></figcaption></figure>
 
 ### Why the site workspace

--- a/docs-site/sites-first.md
+++ b/docs-site/sites-first.md
@@ -12,7 +12,7 @@ tags:
 
 ## The sites-first workspace in GitBook
 
-GitBook is now reorganized to be a site specific. Everything in the app is organized around the docs sites you publish, so what you see while editing matches what your visitors see when reading.
+GitBook is now organized around your docs sites. Everything in the app is arranged around the sites you publish, so what you see while editing matches what your visitors see when reading.
 
 This page explains what changed, what it means for your existing content, and how to opt in.
 

--- a/docs-site/sites-first.md
+++ b/docs-site/sites-first.md
@@ -17,7 +17,7 @@ GitBook is now organized around your docs sites. Everything in the app is arrang
 This page explains what changed, what it means for your existing content, and how to opt in.
 
 {% hint style="info" %}
-**Who has the new experience?** Organizations created in the past month already have it. Any existing organization can enable it today, and we’re gradually rolling it out to everyone. If your app doesn’t match these docs yet, that’s why.
+The new experience is rolling out gradually. New organizations already have it, and existing organizations can enable it today ahead of the global rollout.
 {% endhint %}
 
 <figure><img src="../.gitbook/assets/site-centric @2x.png" alt=""><figcaption></figcaption></figure>


### PR DESCRIPTION
Adds a hint answering "do I have this?" — new orgs already have it, existing orgs can enable it, global rollout is gradual. Pairs with the site-wide announcement banner (set in Customize → Layout → Announcement) and the changelog entry's updated enable line.

Note: still says "enable it today" without a path — the enablement mechanism/location is unverified. Add the click path here once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)