### PR TITLE
Help center absorb batch 2: blocks, editing, accounts, integrations

### DIFF
--- a/account-management/account-settings.md
+++ b/account-management/account-settings.md
@@ -91,3 +91,13 @@ If you _do_ want to reset your password:
 2. Follow the **forgot your password?** link at the bottom of the page
 3. Enter the email address associated with the personal account you signed up for
 4. Click **send a link** (make sure you check your spam folder)
+
+### Troubleshooting sign-in
+
+**Account disabled by administrator** — GitBook automatically blocks accounts exhibiting suspicious behavior to prevent spam and scam accounts. If you believe your account was blocked unfairly, contact support; unblocking requests are assessed case by case.
+
+**The link to join an organization isn't working** — an `auth/invalid-email` error means the email address invited to the organization doesn't match the email of the signed-in GitBook account. Ask the person who invited you which address they used, or ask them to invite a different one.
+
+**Error: auth/expired-action-code** — the sign-in or invitation link has passed its validity period. Generate a new link, or ask the sender for a fresh one.
+
+**Error: auth/email-already-in-use** — the GitHub account you're signing in with is already linked to a different GitBook account. See [Potential duplicated accounts](../getting-started/git-sync/troubleshooting.md#potential-duplicated-accounts-when-signing-in) for the steps to identify and unlink it.

--- a/account-management/organization-settings.md
+++ b/account-management/organization-settings.md
@@ -132,3 +132,18 @@ See our [billing policy](plans/billing-policy.md) to learn how we calculate char
 Click **Manage Billing** to open Stripe. There, you can manage your payment method and billing information. You can also [cancel your plan](cancelling-a-plan.md). If you renew before the billing period ends, your plan continues without interruption.
 
 </details>
+
+### Transfer ownership of an organization
+
+Admins share the same rights in GitBook — they can manage billing, members, and publishing — so transferring ownership means making the new owner an admin:
+
+1. Make sure the new owner is an [admin](../collaboration/member-management/roles.md) in the organization.
+2. To fully hand over, ask the other admin to remove you from the organization. You'll lose access to the organization's content.
+
+To keep the organization but sign in with a different email address, update your email under **Account → General** in the settings screen instead.
+
+### What happens to deleted content
+
+Deleting an organization permanently removes all content associated with it — the same applies to deleting an account that is the sole member of an organization. If a deleted account belonged to an organization with multiple members, the organization's content — including that member's contributions — remains intact.
+
+If content was deleted less than seven days ago, you can restore it from the **Trash**. GitBook doesn't store backups beyond this seven-day window, so content deleted more than seven days ago can't be recovered.

--- a/creating-content/blocks/embed-a-url.md
+++ b/creating-content/blocks/embed-a-url.md
@@ -10,6 +10,10 @@ To add an embedbed URL, simply paste the link of the content you want to embed a
 **Note:** The content you want to embed must be publicly available in order for GitBook to access the file. For example, when embedding a Google doc the share settings must be set to _Anyone with the link_.
 {% endhint %}
 
+{% hint style="info" %}
+GitBook doesn't support embedding external content with an HTML `<iframe>`, due to its content security policy. If the content is publicly available, use the embed block instead.
+{% endhint %}
+
 ### Videos
 
 {% embed url="https://www.youtube.com/watch?v=D_uLM5i0Z4c" %}
@@ -17,6 +21,10 @@ To add an embedbed URL, simply paste the link of the content you want to embed a
 {% hint style="info" %}
 **Note:** You can choose to auto-play and loop YouTube and Vimeo embeds by adding `?autoplay=1&loop=1` to the end of your video’s URL.
 {% endhint %}
+
+#### Video files
+
+Uploaded video files — such as MP4s — don't play inline; they appear as links that visitors can click to open or download. To show a playable video on your page, upload the video to a publicly accessible platform such as YouTube or Google Drive, then paste the link into an embed block. Private URLs won't display on your page.
 
 ### Codepen
 

--- a/creating-content/blocks/expandable.md
+++ b/creating-content/blocks/expandable.md
@@ -56,4 +56,11 @@ Add your expandable body text here. This expandable is collapsed by default.
 
 ### Limitations
 
-There are some limitations on which blocks you can create inside of an expandable block. You can check the full list by starting a new line in an expandable block and pressing `/` to bring up the insert palette.
+There are some limitations on which blocks you can create inside of an expandable block. You can insert the following types of content into expandable blocks:
+
+* Paragraphs
+* Headings (1, 2, and 3)
+* Unordered, ordered, and task lists
+* Inline images
+
+To check the full list at any time, start a new line in an expandable block and press `/` to bring up the insert palette.

--- a/creating-content/blocks/insert-images.md
+++ b/creating-content/blocks/insert-images.md
@@ -29,6 +29,10 @@ If you follow the second process, you can choose to upload a file, select a prev
 GitBook allows you to upload images up to 100MB per file.
 {% endhint %}
 
+There's no set limit on the total number of assets in a section, though GitBook reserves the right to block accounts for abuse. For files larger than the upload limit, store them in a service like Google Drive or Dropbox and link to them from your page.
+
+Animated gifs have a limit of 200 frames per file. Large files — gifs included — slow your page's loading time, so avoid uploading large files directly where you can.
+
 #### Create an image gallery
 
 Adding more than one image to an image block will create a gallery. To do this, open the block’s **Options menu** <picture><source srcset="../../.gitbook/assets/25_01_10_options_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../.gitbook/assets/25_01_10_options_light.svg" alt="The Options menu icon in GitBook"></picture> and choose **Add images…** to open the **Select images** side panel again.
@@ -173,3 +177,11 @@ To add a frame to an image, hover over it, open the block’s **Options menu** <
   <figcaption>Caption text</figcaption>
 </figure>
 ```
+
+### Why is my image not loading?
+
+A "could not load image" error means the image was changed or deleted at its source. If you embedded an image by URL rather than uploading it, GitBook relies on that URL — if the image moves or disappears from the source, it stops displaying on your page.
+
+To resolve it, upload the image directly to GitBook, or update the URL if the image's location changed. The error can also appear when you copy an image from one section to another, because each section has its own file directory — re-upload the image in the new section.
+
+You can review all files uploaded to a section in the **Library** tab, beside **Pages** at the top of the table of contents.

--- a/creating-content/blocks/mermaid-blocks.md
+++ b/creating-content/blocks/mermaid-blocks.md
@@ -37,3 +37,11 @@ flowchart TD
 ````
 
 GitBook renders code blocks with the `mermaid` language identifier as native Mermaid blocks.<br>
+
+### Troubleshooting
+
+If your Mermaid diagram isn't rendering, check these common causes:
+
+* **Syntax errors** — review your Mermaid code for typos, compare it with examples in the Mermaid documentation, or test it in the [Mermaid Live Editor](https://mermaid.live/) to isolate the issue.
+* **Code block instead of Mermaid block** — Mermaid code won't render inside a standard code block. Press `/` and select **Mermaid diagram** to insert the right block type.
+* **Older Mermaid content** — Mermaid is a native block, so no integration is needed. If you created Mermaid content before native block support, GitBook converts it automatically the next time you edit the page.

--- a/creating-content/content-structure/page/README.md
+++ b/creating-content/content-structure/page/README.md
@@ -169,9 +169,16 @@ Both fields support selecting another GitBook page (recommended) or entering an 
 A common pattern for versioned docs is to set older pages to be canonical to the latest equivalent page (for example, `1.0` → `2.0`), and then list older versions as alternates on the latest page.
 {% endhint %}
 
+#### Moving pages between sections
+
+GitBook doesn't currently support moving individual pages between sections in the app. To move a page's content to another section:
+
+* **Copy and paste** — select the page's content with the `Esc` key, then copy and paste it into the destination. Some blocks may need reconfiguring; comments and page history aren't copied, and images need re-uploading in the new section.
+* **Use Git Sync** — if both sections sync with repositories, copy the files between repositories and add the page titles to the destination's `SUMMARY.md`. See [Git Sync](../../../getting-started/git-sync/).
+
 ### Page covers
 
-Set a page cover for each page of your documentation. When you click the **Page cover** <picture><source srcset="../../../.gitbook/assets/25_01_10_image_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../../.gitbook/assets/25_01_10_image_icon_light.svg" alt="The Page cover icon in GitBook"></picture> option, GitBook adds a default cover immediately. From here, you can:
+Set a page cover for each page of your documentation. When you click the **Page cover** <picture><source srcset="../../../.gitbook/assets/25_01_10_image_icon_dark.svg" media="(prefers-color-scheme: dark)"><img src="../../../.gitbook/assets/25_01_10_image_icon_light.svg" alt="The Page cover icon in GitBook"></picture> option, GitBook adds a default cover immediately. The ideal cover image size is 1990 × 480 pixels — covers are locked to this aspect ratio, so the proportions are maintained across screen sizes. From here, you can:
 
 * **Change the cover image**
   1. Hover over the page cover and click **Change cover**.

--- a/creating-content/formatting/README.md
+++ b/creating-content/formatting/README.md
@@ -82,3 +82,7 @@ Click the color icon in the context menu, and choose a color for the text or its
 <mark style="color:orange;">This text is orange.</mark>
 
 <mark style="background-color:orange;">This text background is orange.</mark>
+
+### Right-to-left text
+
+GitBook doesn't currently support right-to-left contributions. Paragraphs and headings automatically detect RTL text and adapt their layout, but lists and other content blocks may not align properly, and font quality can be reduced for some languages.

--- a/docs-site/customization/icons-colors-and-themes.md
+++ b/docs-site/customization/icons-colors-and-themes.md
@@ -16,7 +16,7 @@ You can set any title you choose for your site. Note: this setting will only aff
 
 ### Icon
 
-You can set an emoji, or upload an icon of your own. The icon you set in the **Customize** menu will be used as the favicon for your docs site.
+You can set an emoji, or upload an icon of your own. The icon you set in the **Customize** menu will be used as the favicon for your docs site. Changes can take a few minutes to appear on your published docs — if you don't see the new favicon, your browser may have cached the old one, so try a different browser.
 
 {% hint style="info" %}
 This setting will only affect the icon that displays _in the published documentation_. If you want to edit the icon used within the GitBook app, you can do so when editing content in the section itself.

--- a/getting-started/import.md
+++ b/getting-started/import.md
@@ -63,6 +63,8 @@ GitBook currently has the following limits for imported content:
 * The maximum number of pages that can be uploaded in a single import is **20**.
 * The maximum number of files (images etc.) that can be uploaded in a single import is **20**.
 
+GitBook can't increase these import limits. To import more content at once, use [Git Sync](git-sync/), which supports up to 5,000 Markdown pages.
+
 ***
 
 ## Import from a GitHub or GitLab repo using Git Sync <a href="#import-using-git-sync" id="import-using-git-sync"></a>
@@ -100,3 +102,10 @@ To organize your content, create one or more sections in GitBook as needed. Inst
 When following the configuration process, make sure you select the direction of GitHub → GitBook. This will result in the contents of your folder or repository being pulled from GitHub or GitLab into GitBook.
 {% endstep %}
 {% endstepper %}
+
+## Export your content
+
+You can export your GitBook content in two ways:
+
+* **As Markdown**, by syncing with a Git repository. There's no direct Markdown export in the app — sync the section you want to export with an empty GitHub or GitLab repository using [Git Sync](git-sync/), and the repository becomes your Markdown export. Some blocks don't have a Markdown representation and appear as HTML in the export.
+* **As a PDF**, from the page or section's Actions menu. See [PDF export](../docs-site/pdf-export.md). You may hit limits when exporting very large sections.

--- a/integrations/install-an-integration.md
+++ b/integrations/install-an-integration.md
@@ -40,3 +40,17 @@ Analytics integrations — such as Google Analytics, Segment, or Fathom — are 
 You can now use your integration. Certain integrations may require extra configuration. If so, you’ll see a message asking you to configure your integration in your section or site.
 
 View the integration’s instructions to learn more about configuring it for your team.
+
+### Integrations FAQ
+
+#### Can I request an integration?
+
+Yes — [submit an integration request](https://survey.refiner.io/e61q1m-dp057m), or head to the [GitBook community](https://github.com/GitbookIO/community) to discuss what you'd like to see in GitBook.
+
+#### Can I build my own integration?
+
+The integration platform is available to anyone with a GitBook account. See [our integrations page](https://www.gitbook.com/integrations) or the [developer documentation](https://developer.gitbook.com/) to get started.
+
+#### Does GitBook support Google Tag Manager?
+
+No. Google Tag Manager allows the injection of CSS and JavaScript, which can break sites and carries security concerns, so GitBook doesn't integrate with it.

--- a/resources/concepts.md
+++ b/resources/concepts.md
@@ -37,6 +37,8 @@ The content on your site lives in its sections. When you create a new docs site,
 
 GitBook’s visual editor lets you use a what-you-see-is-what-you-get (WYSIWYG) interface to add content to a section.
 
+Editing is available on desktop and laptop devices. You can view your organization and content from a smartphone, but editing requires a desktop or laptop.
+
 ### Pages
 
 A page is the place where you add, edit and embed content. Pages always live inside a section, and you can add as many pages to a section as you like.


### PR DESCRIPTION
Third slice of the help-center migration — the compound-page fragments and remaining single-page absorbs, rewritten to current terminology and voice. Includes the original example that kicked this project off: expandable-block limitations now live on the Expandable page.

Deliberately NOT imported: the help center's 50MB image-upload claim (main docs says 100MB — contradiction #6, needs a product answer).

Merge order: this PR first, then help-center retire batch 3 (to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)