### PR TITLE
Help center absorb batch 3: publishing cluster

### DIFF
--- a/docs-site/publish-a-docs-site/README.md
+++ b/docs-site/publish-a-docs-site/README.md
@@ -39,9 +39,27 @@ Choose one of these audience options:
 
 <table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-cover data-type="image">Cover image</th><th data-hidden data-card-target data-type="content-ref"></th><th data-hidden data-type="image">Cover image (dark)</th><th data-hidden data-type="image">Cover image (dark)</th><th data-hidden data-card-cover-dark data-type="image">Cover image (dark)</th></tr></thead><tbody><tr><td><strong>Public</strong></td><td>Publish your docs publicly to the web.</td><td></td><td><a href="../../.gitbook/assets/25_12_12_public.png">25_12_12_public.png</a></td><td><a href="public-publishing.md">public-publishing.md</a></td><td><a href="../../.gitbook/assets/25_12_12_public_1.png">25_12_12_public_1.png</a></td><td></td><td><a href="../../.gitbook/assets/25_12_12_public_1.png">25_12_12_public_1.png</a></td></tr><tr><td><strong>Privately with share links</strong></td><td>Publish your docs with private share links.</td><td></td><td><a href="../../.gitbook/assets/25_12_12_share_links_1.png">25_12_12_share_links_1.png</a></td><td><a href="share-links.md">share-links.md</a></td><td></td><td><a href="../../.gitbook/assets/25_12_12_share_links.png">25_12_12_share_links.png</a></td><td><a href="../../.gitbook/assets/25_01_06_share_links@2x.png">25_01_06_share_links@2x.png</a></td></tr><tr><td><strong>Authenticated Access</strong></td><td>Protect your published docs behind an OAuth sign in.</td><td></td><td><a href="../../.gitbook/assets/25_12_10_auth_access_1.png">25_12_10_auth_access_1.png</a></td><td><a href="../../site-access/authenticated-access/">authenticated-access</a></td><td></td><td></td><td><a href="../../.gitbook/assets/25_12_10_auth_access.png">25_12_10_auth_access.png</a></td></tr></tbody></table>
 
+### Preview your site
+
+Click **Preview** in the site header to see your content as visitors will — before you publish the site, or while you're working on changes. Review your content and customizations, then publish when everything looks right.
+
 ### Delete or unpublish a docs site
 
-To unpublish your site, open **Settings** → **General** and select **Unpublish site**.
+To unpublish your site, open **Settings** → **General** and select **Unpublish site**. Once confirmed, the site is no longer accessible to visitors.
+
+Unpublishing doesn't change your billing. To adjust the number of sites you pay for, update your plan in your organization's billing settings.
+
+#### My site is still accessible after unpublishing or deleting
+
+If you can still open the URL, the old version is usually cached — in your browser, a CDN, or a search engine result. To confirm the site is no longer live, open the URL in a private window, or clear your browser cache for that site and reload.
+
+#### My site still appears in search engines
+
+Search engines take time to update their indexes, so an unpublished site can appear in results for a while. How long depends on factors like crawl frequency and how many other sites link to the page.
+
+To speed it up, request a re-crawl from Google Search Console: open the **URL Inspection** tab, enter the URL, and click **Request indexing**. Google reviews the request and removes the page from its index if it's no longer published.
+
+You can check whether your site is still indexed by searching Google for `site:` followed by your site's URL.
 
 To delete a docs site:
 

--- a/docs-site/site-structure/README.md
+++ b/docs-site/site-structure/README.md
@@ -74,3 +74,5 @@ Open the **Actions menu** <picture><source srcset="../../.gitbook/assets/25_01_1
 {% hint style="success" %}
 Removing content from your site will remove it from the published site, but **will not delete the content itself** — you can still find it in [All content](../../creating-content/all-content.md).
 {% endhint %}
+
+If you delete a section's content entirely, the site — along with its settings and customizations — remains available. Deleted content stays in the **Trash** for seven days before it's permanently removed. If the deleted section was your site's default, check that the default is still set correctly.


### PR DESCRIPTION
Absorbs the last decision-free help-center cluster. Main docs won every conflict (unpublish flow already documented — only the billing note moved); new content is limited to what was genuinely uncovered: site preview, post-unpublish cache/indexing troubleshooting, and the delete-a-connected-section note.

Companion help-center retire PR to follow (5 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)