### PR TITLE
Reframe AI search as a placement of the AI Assistant

### DIFF
--- a/documentation/ai-for-your-readers/ai-search.md
+++ b/documentation/ai-for-your-readers/ai-search.md
@@ -1,29 +1,38 @@
 ---
 description: >-
-  Help your users find the information they need faster with powerful AI search
-  tools for your published content
+  Give your readers AI answers directly in the search box of your published
+  content
 ---
 
 # AI Search
 
-Help your users find the information they need faster with powerful knowledge discovery tools for your published content
+Give your readers AI answers directly in the search box of your published content
+
+AI search is a **placement** of [GitBook Assistant](gitbook-ai-assistant.md), not a separate experience you choose instead of it. The same Assistant answers your readers’ questions — the placement decides whether it does so in your site’s sidebar or in its search box.
 
 ### Choose your site’s search experience
 
 GitBook sites offer different search experiences depending on what you want for your users:
 
-* **Keyword search** – A standard search experience based on keywords. Automatically enabled on all sites.
-* **GitBook AI search** – Users get short answers to questions directly from the search box. Available on Premium and Ultimate site plans.
-* **GitBook Assistant** – Users get an advanced, interactive chat experience with GitBook’s AI agent. Available on Ultimate site plans. Head to [GitBook Assistant](gitbook-ai-assistant.md) to learn more.
+* **Keyword search** – A standard search experience based on keywords. Automatically enabled on all sites, and always available whichever placement you choose.
+* **AI search** – The Assistant answers questions directly in the search box. Available on Premium and Ultimate site plans.
+* **GitBook Assistant in the sidebar** – Users get an advanced, interactive chat experience with GitBook’s AI agent. Available on Ultimate site plans. Head to [GitBook Assistant](gitbook-ai-assistant.md) to learn more.
 
-AI Search is available on Premium and Ultimate site plans. GitBook Assistant is available on Ultimate site plans.
+### Turn on AI search
 
-To choose your site’s search experience, open **Customize**, under **Tools** in the site sidebar, and click **AI Assistant**. Here you can choose your preferred experience.
+1. Open **Customize**, under **Tools** in the site sidebar, and click **AI Assistant**.
+2. Turn **AI Assistant** on.
+3. Under **Appearance**, set **Placement** to **Search box**.
+4. Save your changes.
 
-<figure><img src="../.gitbook/assets/26_01_06_search_ai@2x.png" alt=""><figcaption><p>Choose the search experience you want in your published docs</p></figcaption></figure>
+Setting **Placement** to **Sidebar** instead opens the full Assistant chat experience. Sidebar is the default for a newly enabled Assistant.
+
+{% hint style="info" %}
+The Assistant greeting applies to the sidebar placement only, so it’s hidden while **Placement** is set to **Search box**.
+{% endhint %}
 
 {% hint style="warning" %}
-When GitBook Assistant is enabled, AI search is disabled. Standard keyword searches will always provide the results in the search bar no matter which experience you choose.
+Turning **AI Assistant** off and on again resets **Placement** to **Sidebar**. If your site uses the search box placement, set it again after re-enabling the Assistant.
 {% endhint %}
 
 ## Searching published documentation
@@ -34,24 +43,20 @@ Your users can search for keywords within your docs site and jump quickly to spe
 
 If your docs site has multiple [sections](../manage-your-site/site-structure/site-sections.md), the search results will contain pages from all of these sections so that you users can jump straight to the page they need.
 
-## GitBook AI search
+## AI search
 
-GitBook AI search offers basic AI-powered answers in the **Search and find…** bar of your site. It’s trained on the content of your docs site, but cannot pull in information from external sources.
+With **Placement** set to **Search box**, the Assistant offers AI-powered answers in the **Ask or search…** bar of your site. It’s trained on the content of your docs site, and can also draw on any sources you’ve added through [connections](connections.md).
 
-### Using GitBook AI search
+### Using AI search
 
-If you have enabled GitBook AI search from your site’s settings page, your users can access it by asking a question directly in the **Ask or search…** bar at the top of the page.
+Your users can access it by asking a question directly in the **Ask or search…** bar at the top of the page.
 
 They can open this by clicking it directly, or by pressing <kbd>⌘</kbd> + <kbd>K</kbd> on a Mac or <kbd>Ctrl</kbd> + <kbd>K</kbd> on a PC.
 
-As well as a summarized answer, below your users will also see an expandable section that shows the sources that GitBook AI used to create its answer, plus related questions you can click as a follow-up.
+As well as a summarized answer, below your users will also see an expandable section that shows the sources that the Assistant used to create its answer, plus related questions you can click as a follow-up.
 
 {% hint style="warning" %}
-GitBook AI does not work across individual published sections on different [docs sites](../publish/publish-a-docs-site/).
+AI search does not work across individual published sections on different [docs sites](../publish/publish-a-docs-site/).
 
 Multi-section search is only available when viewing published [sections](../manage-your-site/site-structure/site-sections.md) that live within the same site.
 {% endhint %}
-
-* Press <kbd>⌘</kbd> + <kbd>I</kbd> on Mac or <kbd>Ctrl</kbd> + <kbd>I</kbd> on PC
-* Click the **GitBook Assistant** ![](../.gitbook/assets/25_07_16_gitbook_assistant_1.svg) button next to the **Ask or search…** bar
-* Type a question into the **Ask or search…** bar and choose the ‘Ask…’ option at the top of the menu.

--- a/documentation/ai-for-your-readers/ai-search.md
+++ b/documentation/ai-for-your-readers/ai-search.md
@@ -1,31 +1,21 @@
 ---
-description: >-
-  Give your readers AI answers directly in the search box of your published
-  content
+description: GitBook Assistant, shown in your site’s search box
 ---
 
 # AI Search
 
-Give your readers AI answers directly in the search box of your published content
+AI Search is [GitBook Assistant](gitbook-ai-assistant.md), shown in your site’s search box.
 
-AI search is a **placement** of [GitBook Assistant](gitbook-ai-assistant.md), not a separate experience you choose instead of it. The same Assistant answers your readers’ questions — the placement decides whether it does so in your site’s sidebar or in its search box.
+Turning the Assistant on gives your readers AI answers drawn from your content. **Placement** decides where they reach it: in the sidebar, as a full chat experience, or in the search box, as answers inline. AI Search is the search box placement.
 
-### Choose your site’s search experience
-
-GitBook sites offer different search experiences depending on what you want for your users:
-
-* **Keyword search** – A standard search experience based on keywords. Automatically enabled on all sites, and always available whichever placement you choose.
-* **AI search** – The Assistant answers questions directly in the search box. Available on Premium and Ultimate site plans.
-* **GitBook Assistant in the sidebar** – Users get an advanced, interactive chat experience with GitBook’s AI agent. Available on Ultimate site plans. Head to [GitBook Assistant](gitbook-ai-assistant.md) to learn more.
-
-### Turn on AI search
+### Show the Assistant in your search box <a href="#choose-your-sites-search-experience" id="choose-your-sites-search-experience"></a>
 
 1. Open **Customize**, under **Tools** in the site sidebar, and click **AI Assistant**.
 2. Turn **AI Assistant** on.
 3. Under **Appearance**, set **Placement** to **Search box**.
 4. Save your changes.
 
-Setting **Placement** to **Sidebar** instead opens the full Assistant chat experience. Sidebar is the default for a newly enabled Assistant.
+Sidebar is the default placement for a newly enabled Assistant. The search box placement is available on Premium and Ultimate site plans; the sidebar placement is available on Ultimate.
 
 {% hint style="info" %}
 The Assistant greeting applies to the sidebar placement only, so it’s hidden while **Placement** is set to **Search box**.
@@ -37,26 +27,26 @@ Turning **AI Assistant** off and on again resets **Placement** to **Sidebar**. I
 
 ## Searching published documentation
 
+Keyword search is automatically enabled on every site, whether or not the Assistant is turned on.
+
 **​**Users can open the **Ask or search…** bar by pressing <kbd>⌘</kbd> + <kbd>K</kbd> on Mac or <kbd>Ctrl</kbd> + <kbd>K</kbd> on PC.
 
 Your users can search for keywords within your docs site and jump quickly to specific pages or page sections across your entire site.
 
 If your docs site has multiple [sections](../manage-your-site/site-structure/site-sections.md), the search results will contain pages from all of these sections so that you users can jump straight to the page they need.
 
-## AI search
+## Asking questions in the search box
 
-With **Placement** set to **Search box**, the Assistant offers AI-powered answers in the **Ask or search…** bar of your site. It’s trained on the content of your docs site, and can also draw on any sources you’ve added through [connections](connections.md).
-
-### Using AI search
-
-Your users can access it by asking a question directly in the **Ask or search…** bar at the top of the page.
+With **Placement** set to **Search box**, your users can ask a question directly in the **Ask or search…** bar at the top of the page, alongside the keyword results.
 
 They can open this by clicking it directly, or by pressing <kbd>⌘</kbd> + <kbd>K</kbd> on a Mac or <kbd>Ctrl</kbd> + <kbd>K</kbd> on a PC.
 
 As well as a summarized answer, below your users will also see an expandable section that shows the sources that the Assistant used to create its answer, plus related questions you can click as a follow-up.
 
+The Assistant answers from the content of your docs site, and from any sources you’ve added through [connections](connections.md).
+
 {% hint style="warning" %}
-AI search does not work across individual published sections on different [docs sites](../publish/publish-a-docs-site/).
+The Assistant does not answer across individual published sections on different [docs sites](../publish/publish-a-docs-site/).
 
 Multi-section search is only available when viewing published [sections](../manage-your-site/site-structure/site-sections.md) that live within the same site.
 {% endhint %}

--- a/documentation/manage-your-site/site-settings.md
+++ b/documentation/manage-your-site/site-settings.md
@@ -144,13 +144,21 @@ You can review the results of these ratings by opening [site analytics](../analy
 
 ### AI & MCP
 
-AI settings are available on different plans. AI Search is available on Premium and Ultimate site plans. GitBook Assistant and MCP connectors are available on Ultimate.
+AI settings are available on different plans. The search box placement is available on Premium and Ultimate site plans. The sidebar placement and MCP connectors are available on Ultimate.
 
 <details>
 
-<summary>Choose the AI experience <picture><source srcset="../.gitbook/assets/Premium Badge Dark.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Premium Badge Light.png" alt=""></picture> <picture><source srcset="../.gitbook/assets/Ultimate Badge Dark.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Ultimate Badge Light.png" alt=""></picture></summary>
+<summary>AI Assistant <picture><source srcset="../.gitbook/assets/Premium Badge Dark.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Premium Badge Light.png" alt=""></picture> <picture><source srcset="../.gitbook/assets/Ultimate Badge Dark.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Ultimate Badge Light.png" alt=""></picture></summary>
 
-Choose the search experience for your site. AI Search is available on Premium and Ultimate site plans. GitBook Assistant is available on Ultimate site plans. See [ai-search.md](../ai-for-your-readers/ai-search.md "mention") for more info.
+Turn GitBook Assistant on or off for your site. See [gitbook-ai-assistant.md](../ai-for-your-readers/gitbook-ai-assistant.md "mention") for more info.
+
+</details>
+
+<details>
+
+<summary>Appearance <picture><source srcset="../.gitbook/assets/Premium Badge Dark.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Premium Badge Light.png" alt=""></picture> <picture><source srcset="../.gitbook/assets/Ultimate Badge Dark.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Ultimate Badge Light.png" alt=""></picture></summary>
+
+Choose where the Assistant appears using **Placement** — **Sidebar** for the full chat experience, available on Ultimate site plans, or **Search box** to answer questions in your site’s search bar, available on Premium and Ultimate site plans. You can also set the Assistant greeting here, which applies to the sidebar placement only. See [ai-search.md](../ai-for-your-readers/ai-search.md "mention") for more info.
 
 </details>
 
@@ -158,7 +166,7 @@ Choose the search experience for your site. AI Search is available on Premium an
 
 <summary>Extend GitBook Assistant with MCP connectors <picture><source srcset="../.gitbook/assets/Ultimate Badge Dark.png" media="(prefers-color-scheme: dark)"><img src="../.gitbook/assets/Ultimate Badge Light.png" alt=""></picture></summary>
 
-Configure MCP servers that GitBook Assistant can use when answering questions inside your docs. This setting is available on Ultimate site plans. See [#how-do-i-use-gitbook-ai](../ai-for-your-readers/ai-search.md#how-do-i-use-gitbook-ai "mention") for more info.
+Configure MCP servers that GitBook Assistant can use when answering questions inside your docs. This setting is available on Ultimate site plans. See [mcp-servers-for-published-docs.md](../ai-for-your-readers/mcp-servers-for-published-docs.md "mention") for more info.
 
 </details>
 


### PR DESCRIPTION
Updates the two pages that describe the site AI settings to match [GitbookIO/gitbook-x#25087](https://github.com/GitbookIO/gitbook-x/pull/25087) (merged 2026-08-25), which replaced the three-way AI experience picker with a single **AI Assistant** toggle plus an **Appearance** panel holding a **Placement** option.

## What changed in the product

- The None / AI search / GitBook Assistant tile picker is gone.
- **AI Assistant** is now an on/off toggle (off → `ai.mode: none`, on → `ai.mode: assistant`).
- **Appearance** → **Placement** chooses **Sidebar** (default, `assistant`) or **Search box** (`search`).
- The Assistant greeting moved under Appearance and is hidden for the search box placement.
- Custom instructions moved below Appearance.

## Doc changes

**`documentation/ai-for-your-readers/ai-search.md`**
- AI search is described as the search box *placement* of the Assistant, not a rival experience.
- Added explicit enable steps (toggle on → Appearance → Placement → Search box).
- Removed the now-false warning that AI search is disabled when the Assistant is enabled.
- Removed the screenshot of the deleted tile picker — **needs a replacement capture** of the new AI tab.
- Removed three stray bullets at the end of the page that duplicated the access methods already on the GitBook Assistant page.
- Corrected "Search and find…" → "Ask or search…" to match the actual bar label.

**`documentation/manage-your-site/site-settings.md`**
- Replaced the "Choose the AI experience" entry with **AI Assistant** and **Appearance** entries.
- Repointed the MCP connectors link at `mcp-servers-for-published-docs.md`; the previous link used an anchor (`#how-do-i-use-gitbook-ai`) that does not exist on `ai-search.md`.

## Open questions for review

1. **Is this live in production yet?** The PR merged two days ago. If the new AI tab is still behind a flag, this should wait rather than merge.
2. **Off/on resets placement.** The upstream PR notes a site on `search` that is toggled off and back on lands on `assistant`. I documented this as a warning hint — happy to cut it if it is considered a transient bug rather than intended behaviour.
3. **External sources claim.** The old text said AI search "cannot pull in information from external sources", which contradicts `connections.md`. I changed it to reference connections — worth confirming.
4. **Not touched, but stale:** `guides/editing-and-publishing-documentation/complete-guide-to-publishing-docs-gitbook.md:103` still describes choosing "none, AI search or the full AI Assistant experience", and `gitbook-ai-assistant.md:22` does not mention Placement. Both are outside the two pages requested — say the word and I will add them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)