### PR TITLE
Rename docs.yaml to gitbook-docs.yaml

### DIFF
--- a/documentation/docs-as-code/git-sync/content-configuration.md
+++ b/documentation/docs-as-code/git-sync/content-configuration.md
@@ -6,19 +6,19 @@ description: Configure Git Sync through code
 
 Git Sync uses three files. Choose the file that controls the part of Git Sync you need:
 
-* `docs.yaml` configures the site and maps spaces to repository directories.
+* `gitbook-docs.yaml` configures the site and maps spaces to repository directories.
 * `.gitbook.yaml` configures how GitBook reads one space’s content.
 * `SUMMARY.md` defines a space’s navigation.
 
-### Configure the site with docs.yaml
+### Configure the site with gitbook-docs.yaml
 
-`docs.yaml` configures the entire site. It lives in the Git Sync Project directory. GitBook uses the repository root when you don't set a **Project directory**.
+`gitbook-docs.yaml` configures the entire site. It lives in the Git Sync Project directory. GitBook uses the repository root when you don't set a **Project directory**.
 
-Use `docs.yaml` to define your site structure and map each space to a directory. Each item in `site.structure` has a stable `key`. A space’s `content.directory` sets its repository directory.
+Use `gitbook-docs.yaml` to define your site structure and map each space to a directory. Each item in `site.structure` has a stable `key`. A space’s `content.directory` sets its repository directory.
 
 #### Keys identify your spaces
 
-Git Sync recognizes each space and section by its `key`, not by its title, path, or directory. The key is how GitBook matches an entry in `docs.yaml` to existing content from one sync to the next.
+Git Sync recognizes each space and section by its `key`, not by its title, path, or directory. The key is how GitBook matches an entry in `gitbook-docs.yaml` to existing content from one sync to the next.
 
 {% hint style="danger" %}
 **Changing a space’s `key` replaces that space.** GitBook treats the old key as removed and the new key as a new space. It creates a new space, imports your content into it from the mapped directory, and leaves the original space in your organization, detached from the site.
@@ -35,7 +35,7 @@ Keys are safe to choose freely when you first create an entry, and GitBook gener
 
 This example maps English and French spaces to separate directories:
 
-{% code title="docs.yaml" expandable="true" %}
+{% code title="gitbook-docs.yaml" expandable="true" %}
 ```yaml
 $schema: https://api.gitbook.com/openapi.yaml#/components/schemas/GitSyncSiteConfig
 site:
@@ -79,7 +79,7 @@ Use these optional properties to refine your site structure:
 | `localizedDescription` | Translate a section description.                          |
 | `hidden`               | Hide a space from site navigation.                        |
 
-GitBook creates or updates `docs.yaml` when it saves the site content mapping.
+GitBook creates or updates `gitbook-docs.yaml` when it saves the site content mapping.
 
 </details>
 

--- a/documentation/docs-as-code/git-sync/enabling-github-sync.md
+++ b/documentation/docs-as-code/git-sync/enabling-github-sync.md
@@ -56,7 +56,7 @@ Before you start the initial sync, confirm the repository, branch, and direction
 {% step %}
 ### Set the project directory
 
-If your documentation lives in a subdirectory, enter it under **Project directory**. GitBook stores your site’s `docs.yaml` file in this directory. Use this configuration if your docs live within a [monorepo](monorepos.md).
+If your documentation lives in a subdirectory, enter it under **Project directory**. GitBook stores your site’s `gitbook-docs.yaml` file in this directory. Use this configuration if your docs live within a [monorepo](monorepos.md).
 {% endstep %}
 
 {% step %}

--- a/documentation/docs-as-code/git-sync/enabling-gitlab-sync.md
+++ b/documentation/docs-as-code/git-sync/enabling-gitlab-sync.md
@@ -52,7 +52,7 @@ Choose the source of truth for the initial sync. Select **Swap direction** if th
 {% step %}
 ### Set the project directory
 
-If your documentation lives in a subdirectory, enter it under **Project directory**. GitBook stores your site’s `docs.yaml` file in this directory. Use this configuration if your docs live within a [monorepo](monorepos.md).
+If your documentation lives in a subdirectory, enter it under **Project directory**. GitBook stores your site’s `gitbook-docs.yaml` file in this directory. Use this configuration if your docs live within a [monorepo](monorepos.md).
 {% endstep %}
 
 {% step %}

--- a/documentation/docs-as-code/git-sync/monorepos.md
+++ b/documentation/docs-as-code/git-sync/monorepos.md
@@ -4,19 +4,19 @@ description: Use Git Sync with monorepos and map spaces to separate directories
 
 # Monorepos
 
-Use site-wide Git Sync to sync multiple spaces from one repository and branch. Map each space to its own directory in `docs.yaml`.
+Use site-wide Git Sync to sync multiple spaces from one repository and branch. Map each space to its own directory in `gitbook-docs.yaml`.
 
 ### How site-wide Git Sync works
 
-The site’s **Project directory** sets the Git Sync installation directory. `docs.yaml` lives there. If you leave it empty, GitBook uses the repository root.
+The site’s **Project directory** sets the Git Sync installation directory. `gitbook-docs.yaml` lives there. If you leave it empty, GitBook uses the repository root.
 
-In `docs.yaml`, each space has a `content.directory`. That directory contains the space’s `.gitbook.yaml`, `README.md`, `SUMMARY.md`, and content files.
+In `gitbook-docs.yaml`, each space has a `content.directory`. That directory contains the space’s `.gitbook.yaml`, `README.md`, `SUMMARY.md`, and content files.
 
 For an overview of these files, see [Content configuration](content-configuration.md).
 
 ### Map spaces to directories
 
-Use **Content mapping** in the Git Sync panel to map each space. GitBook saves the mapping in `docs.yaml`.
+Use **Content mapping** in the Git Sync panel to map each space. GitBook saves the mapping in `gitbook-docs.yaml`.
 
 Directory paths work as follows:
 
@@ -30,7 +30,7 @@ For example, this repository maps three spaces:
 
 ```
 /
-  docs.yaml
+  gitbook-docs.yaml
   documentation/
     .gitbook.yaml
     README.md
@@ -48,9 +48,9 @@ For example, this repository maps three spaces:
     SUMMARY.md
 ```
 
-This `docs.yaml` maps each space to its directory:
+This `gitbook-docs.yaml` maps each space to its directory:
 
-{% code title="docs.yaml" %}
+{% code title="gitbook-docs.yaml" %}
 ```yaml
 $schema: https://api.gitbook.com/openapi.yaml#/components/schemas/GitSyncSiteConfig
 site:
@@ -89,7 +89,7 @@ The `.gitbook.yaml` `root` setting controls where GitBook reads content within t
 Move a space’s content by updating its files and mapping together:
 
 1. In the repository, move the space’s content files and assets.
-2. In `docs.yaml`, update that space’s `content.directory`. Leave its `key` unchanged.
+2. In `gitbook-docs.yaml`, update that space’s `content.directory`. Leave its `key` unchanged.
 3. Commit both changes in the same commit.
 
 {% hint style="info" %}

--- a/documentation/docs-as-code/git-sync/troubleshooting.md
+++ b/documentation/docs-as-code/git-sync/troubleshooting.md
@@ -92,9 +92,9 @@ Your `SUMMARY.md` file mirrors your table of contents on GitBook — the way it'
 
 <details>
 
-<summary>My links to another space return 404 after I edited <code>docs.yaml</code></summary>
+<summary>My links to another space return 404 after I edited <code>gitbook-docs.yaml</code></summary>
 
-Cross-space links resolve through space IDs. Git Sync identifies each space in `docs.yaml` by its `key`, so changing a space’s key replaces that space: GitBook creates a new one, imports your content into it from the mapped directory, and leaves the original space in your organization, detached from the site.
+Cross-space links resolve through space IDs. Git Sync identifies each space in `gitbook-docs.yaml` by its `key`, so changing a space’s key replaces that space: GitBook creates a new one, imports your content into it from the mapped directory, and leaves the original space in your organization, detached from the site.
 
 Your pages come back, but the space ID changes. Links, cards, and `SUMMARY.md` entries that point at the old ID break.
 


### PR DESCRIPTION
Follows GitbookIO/gitbook-x#25100. Mechanical rename of 22 occurrences across 5 Git Sync pages.

## Two questions for @taranvohra

**Do existing repos need to rename their `docs.yaml`, or does GitBook write `gitbook-docs.yaml` for them on the next sync?** 

**Should the examples use the new `$schema` URL?** They still point at `api.gitbook.com/openapi.yaml#/components/schemas/GitSyncSiteConfig`, while our own config uses `api.gitbook.com/gitbook-docs.yaml`. Happy to switch if that's the one to copy?
